### PR TITLE
Fix log viewer test issues and update snapshots

### DIFF
--- a/infrastructure/test-umbraco/MCPTestSite/Views/Partials/_ExistingStylesheet.css.cshtml
+++ b/infrastructure/test-umbraco/MCPTestSite/Views/Partials/_ExistingStylesheet.css.cshtml
@@ -1,1 +1,0 @@
-﻿/* Existing content */.existing { display: block; }

--- a/infrastructure/test-umbraco/MCPTestSite/Views/Partials/_TestCreateStylesheet.css.cshtml
+++ b/infrastructure/test-umbraco/MCPTestSite/Views/Partials/_TestCreateStylesheet.css.cshtml
@@ -1,1 +1,0 @@
-﻿/* Test create stylesheet */body {  color: #333;  font-family: Arial, sans-serif;}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eval-mcp:basic": "npx mcp-server-tester evals tests/e2e/basic/basic-tests.yaml --server-config tests/e2e/basic/basic-tests-config.json",
     "eval-mcp:create-data-type": "npx mcp-server-tester evals tests/e2e/create-data-type/create-data-type.yaml --server-config tests/e2e/create-data-type/create-data-type-config.json",
     "eval-mcp:create-document-type": "npx mcp-server-tester evals tests/e2e/create-document-type/create-document-type.yaml --server-config tests/e2e/create-document-type/create-document-type-config.json",
-    "eval-mcp:create-blog-post": "npx mcp-server-tester evals tests/e2e/create-blog-post/create-blog-post.yaml --server-config tests/e2e/create-blog-post/create-blog-post-config.json --debug",
+    "eval-mcp:create-blog-post": "npx mcp-server-tester evals tests/e2e/create-blog-post/create-blog-post.yaml --server-config tests/e2e/create-blog-post/create-blog-post-config.json",
     "eval-mcp:all": "npm run eval-mcp:basic && npm run eval-mcp:create-data-type && npm run eval-mcp:create-document-type && npm run eval-mcp:create-blog-post"
   },
   "engines": {

--- a/src/umb-management-api/tools/document-blueprint/__tests__/__snapshots__/get-document-blueprint-tree.test.ts.snap
+++ b/src/umb-management-api/tools/document-blueprint/__tests__/__snapshots__/get-document-blueprint-tree.test.ts.snap
@@ -26,7 +26,7 @@ exports[`document-blueprint-tree children should get child items 1`] = `
 {
   "content": [
     {
-      "text": "{"total":1,"items":[{"documentType":{"id":"a95360e8-ff04-40b1-8f46-7aa4b5983096","icon":"icon-home color-blue","collection":null},"isFolder":false,"name":"_Test Child Blueprint","id":"00000000-0000-0000-0000-000000000000","parent":{"id":"00000000-0000-0000-0000-000000000000"},"hasChildren":false}]}",
+      "text": "{"total":1,"items":[{"documentType":{"id":"00000000-0000-0000-0000-000000000000","icon":"icon-home color-blue","collection":null},"isFolder":false,"name":"_Test Child Blueprint","id":"00000000-0000-0000-0000-000000000000","parent":{"id":"00000000-0000-0000-0000-000000000000"},"hasChildren":false}]}",
       "type": "text",
     },
   ],

--- a/src/umb-management-api/tools/document-version/__tests__/__snapshots__/get-document-version.test.ts.snap
+++ b/src/umb-management-api/tools/document-version/__tests__/__snapshots__/get-document-version.test.ts.snap
@@ -11,11 +11,13 @@ exports[`get-document-version should handle non-existent document 1`] = `
     "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
     "title": "One or more validation errors occurred.",
     "status": 400,
-    "errors": {
-      "documentId": [
-        "The value 'non-existent-id' is not valid."
-      ]
-    },
+    "errors": [
+      {
+        "$.documentId": [
+          "The value 'non-existent-id' is not valid."
+        ]
+      }
+    ],
     "traceId": "normalized-trace-id"
   }
 }",

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/get-document-publish.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/get-document-publish.test.ts.snap
@@ -4,7 +4,7 @@ exports[`get-document-publish should get the published state of a published docu
 {
   "content": [
     {
-      "text": "{"urls":[],"template":null,"isTrashed":false,"documentType":{"id":"a95360e8-ff04-40b1-8f46-7aa4b5983096","icon":"icon-home color-blue","collection":null},"id":"00000000-0000-0000-0000-000000000000","values":[],"variants":[{"state":"Published","publishDate":"NORMALIZED_DATE","scheduledPublishDate":null,"scheduledUnpublishDate":null,"createDate":"NORMALIZED_DATE","updateDate":"NORMALIZED_DATE","culture":null,"segment":null,"name":"_Test GetDocumentPublish"}]}",
+      "text": "{"urls":[],"template":null,"isTrashed":false,"documentType":{"id":"00000000-0000-0000-0000-000000000000","icon":"icon-home color-blue","collection":null},"id":"00000000-0000-0000-0000-000000000000","values":[],"variants":[{"state":"Published","publishDate":"NORMALIZED_DATE","scheduledPublishDate":null,"scheduledUnpublishDate":null,"createDate":"NORMALIZED_DATE","updateDate":"NORMALIZED_DATE","culture":null,"segment":null,"name":"_Test GetDocumentPublish"}]}",
       "type": "text",
     },
   ],

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/get-document-tree.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/get-document-tree.test.ts.snap
@@ -4,7 +4,7 @@ exports[`document-tree ancestors should get ancestor items 1`] = `
 {
   "content": [
     {
-      "text": "[{"isProtected":false,"ancestors":[],"documentType":{"id":"a95360e8-ff04-40b1-8f46-7aa4b5983096","icon":"icon-home color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test Root Document","culture":null}],"noAccess":false,"isTrashed":false,"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","parent":null,"hasChildren":true},{"isProtected":false,"ancestors":[{"id":"00000000-0000-0000-0000-000000000000"}],"documentType":{"id":"b871f83c-2395-4894-be0f-5422c1a71e48","icon":"icon-document color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test Child Document","culture":null}],"noAccess":false,"isTrashed":false,"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","parent":{"id":"00000000-0000-0000-0000-000000000000"},"hasChildren":false}]",
+      "text": "[{"isProtected":false,"ancestors":[],"documentType":{"id":"00000000-0000-0000-0000-000000000000","icon":"icon-home color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test Root Document","culture":null}],"noAccess":false,"isTrashed":false,"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","parent":null,"hasChildren":true},{"isProtected":false,"ancestors":[{"id":"00000000-0000-0000-0000-000000000000"}],"documentType":{"id":"00000000-0000-0000-0000-000000000000","icon":"icon-document color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test Child Document","culture":null}],"noAccess":false,"isTrashed":false,"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","parent":{"id":"00000000-0000-0000-0000-000000000000"},"hasChildren":false}]",
       "type": "text",
     },
   ],
@@ -26,7 +26,7 @@ exports[`document-tree children should get child items 1`] = `
 {
   "content": [
     {
-      "text": "{"total":1,"items":[{"isProtected":false,"ancestors":[{"id":"00000000-0000-0000-0000-000000000000"}],"documentType":{"id":"b871f83c-2395-4894-be0f-5422c1a71e48","icon":"icon-document color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test Child Document","culture":null}],"noAccess":false,"isTrashed":false,"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","parent":{"id":"00000000-0000-0000-0000-000000000000"},"hasChildren":false}]}",
+      "text": "{"total":1,"items":[{"isProtected":false,"ancestors":[{"id":"00000000-0000-0000-0000-000000000000"}],"documentType":{"id":"00000000-0000-0000-0000-000000000000","icon":"icon-document color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test Child Document","culture":null}],"noAccess":false,"isTrashed":false,"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","parent":{"id":"00000000-0000-0000-0000-000000000000"},"hasChildren":false}]}",
       "type": "text",
     },
   ],

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/get-recycle-bin-tree.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/get-recycle-bin-tree.test.ts.snap
@@ -26,7 +26,7 @@ exports[`recycle-bin-tree root should get recycle bin root items 1`] = `
 {
   "content": [
     {
-      "text": "{"total":1,"items":[{"documentType":{"id":"a95360e8-ff04-40b1-8f46-7aa4b5983096","icon":"icon-home color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test RecycleBin Root","culture":null}],"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","hasChildren":false,"parent":null}]}",
+      "text": "{"total":1,"items":[{"documentType":{"id":"00000000-0000-0000-0000-000000000000","icon":"icon-home color-blue","collection":null},"variants":[{"state":"Draft","name":"_Test RecycleBin Root","culture":null}],"id":"00000000-0000-0000-0000-000000000000","createDate":"NORMALIZED_DATE","hasChildren":false,"parent":null}]}",
       "type": "text",
     },
   ],

--- a/src/umb-management-api/tools/log-viewer/__tests__/get-log-viewer-log.test.ts
+++ b/src/umb-management-api/tools/log-viewer/__tests__/get-log-viewer-log.test.ts
@@ -50,7 +50,8 @@ describe("get-log-viewer-log", () => {
 
     // Verify the items are within the date range
     const itemDate = new Date(response.items[0].timestamp).getTime();
+    const nowAfterCall = new Date().getTime(); // Capture current time after API call
     expect(itemDate).toBeGreaterThanOrEqual(oneMonthAgo.getTime());
-    expect(itemDate).toBeLessThanOrEqual(now.getTime());
+    expect(itemDate).toBeLessThanOrEqual(nowAfterCall);
   });
 });

--- a/src/umb-management-api/tools/log-viewer/__tests__/helpers/log-viewer-test-helper.ts
+++ b/src/umb-management-api/tools/log-viewer/__tests__/helpers/log-viewer-test-helper.ts
@@ -38,7 +38,7 @@ export class LogViewerTestHelper {
           messageTemplate: expect.any(String),
           renderedMessage: expect.any(String),
           properties: expect.any(Array),
-          exception: expect.toBeOneOf([expect.any(Object), null]),
+          exception: expect.toBeOneOf([expect.any(Object), expect.any(String), null]),
         })
       );
     }

--- a/tests/e2e/basic/basic-tests-config.json
+++ b/tests/e2e/basic/basic-tests-config.json
@@ -7,7 +7,7 @@
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
         "UMBRACO_CLIENT_SECRET": "1234567890",
         "UMBRACO_BASE_URL": "http://localhost:56472",
-        "UMBRACO_MCP_INCLUDE_TOOLS": "get-document-type-configuration,get-document-root,get-document-by-id,create-data-type-folder,get-data-type-root,find-data-type,move-data-type,delete-data-type-folder"
+        "INCLUDE_MANAGEMENT_TOOLS": "get-document-type-configuration,get-document-root,get-document-by-id,create-data-type-folder,get-data-type-root,find-data-type,move-data-type,delete-data-type-folder"
       }
     }
   }

--- a/tests/e2e/create-blog-post/create-blog-post-config.json
+++ b/tests/e2e/create-blog-post/create-blog-post-config.json
@@ -7,7 +7,7 @@
           "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
           "UMBRACO_CLIENT_SECRET": "1234567890",
           "UMBRACO_BASE_URL": "http://localhost:56472",
-          "UMBRACO_MCP_INCLUDE_TOOLS": "search-document,get-document-by-id,copy-document,publish-document,delete-document,get-document-root,get-document-children,get-document-publish,get-document-type-by-id,get-all-document-types"
+          "INCLUDE_MANAGEMENT_TOOLS": "search-document,get-document-by-id,copy-document,publish-document,delete-document,get-document-root,get-document-children,get-document-publish,get-document-type-by-id,get-all-document-types"
         }
       }
     }

--- a/tests/e2e/create-data-type/create-data-type-config.json
+++ b/tests/e2e/create-data-type/create-data-type-config.json
@@ -7,7 +7,7 @@
           "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
           "UMBRACO_CLIENT_SECRET": "1234567890",
           "UMBRACO_BASE_URL": "http://localhost:56472",
-          "UMBRACO_MCP_INCLUDE_TOOLS": "create-data-type,delete-data-type,get-data-type-root"
+          "INCLUDE_MANAGEMENT_TOOLS": "create-data-type,delete-data-type,get-data-type-root"
         }
       }
     }

--- a/tests/e2e/create-document-type/create-document-type-config.json
+++ b/tests/e2e/create-document-type/create-document-type-config.json
@@ -7,7 +7,7 @@
           "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
           "UMBRACO_CLIENT_SECRET": "1234567890",
           "UMBRACO_BASE_URL": "http://localhost:56472",
-          "UMBRACO_MCP_INCLUDE_TOOLS": "get-icons,get-all-document-types,create-document-type,delete-document-type,find-data-type,get-document-type-root,get-document-type-by-id"
+          "INCLUDE_MANAGEMENT_TOOLS": "get-icons,get-all-document-types,create-document-type,delete-document-type,find-data-type,get-document-type-root,get-document-type-by-id"
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fix log viewer test helper to properly handle exception fields as strings
- Fix timestamp race condition in log viewer custom parameters test
- Update various test snapshots with properly normalized document type IDs
- Clean up acceptance test configuration files
- Remove unused stylesheet test partial views

## Changes Made

### Log Viewer Test Fixes
- **Exception field handling**: Updated `LogViewerTestHelper.verifyLogResponse()` to accept exception field as `string`, `object`, or `null` (previously only accepted `object` or `null`)
- **Timestamp race condition**: Fixed "should get log viewer logs with custom parameters" test by capturing timestamp after API call completion instead of before

### Snapshot Updates
- Updated snapshots for document tree operations with properly normalized document type IDs
- Accepted snapshots for:
  - `get-document-version.test.ts`
  - `get-document-publish.test.ts` 
  - `get-document-tree.test.ts`
  - `get-recycle-bin-tree.test.ts`
  - `get-document-blueprint-tree.test.ts`

### Configuration Cleanup
- Updated acceptance test configuration files with specific tool inclusions
- Removed unused stylesheet test partial view files

## Test Results
All affected tests now pass with the updated snapshot normalizations and timing fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)