### PR TITLE
Add multiple culture support to create-document tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,3 @@ dist
 **/.gemini/settings.json
 **/.qwen/settings.json
 **/.roo/mcp.json
-/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ dist
 **/.gemini/settings.json
 **/.qwen/settings.json
 **/.roo/mcp.json
+/tmp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@umbraco-mcp/umbraco-mcp-cms",
-  "version": "0.1.0-alpha.7",
+  "name": "@umbraco-cms/mcp-dev",
+  "version": "16.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@umbraco-mcp/umbraco-mcp-cms",
-      "version": "0.1.0-alpha.7",
+      "name": "@umbraco-cms/mcp-dev",
+      "version": "16.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/src/umb-management-api/tools/document/__tests__/create-document.test.ts
+++ b/src/umb-management-api/tools/document/__tests__/create-document.test.ts
@@ -98,8 +98,8 @@ describe("create-document", () => {
     expect(cultures).toEqual(["da-DK", "en-US"]);
   });
 
-  it("should create a document with empty cultures array (null culture)", async () => {
-    // Create document with empty cultures array - should behave like original
+  it("should create a document with empty cultures array (auto-fetch behavior)", async () => {
+    // Create document with empty cultures array - should behave same as no cultures parameter
     const docModel = {
       documentTypeId: ROOT_DOCUMENT_TYPE_ID,
       name: TEST_DOCUMENT_NAME,
@@ -115,8 +115,8 @@ describe("create-document", () => {
 
     const item = await DocumentTestHelper.findDocument(TEST_DOCUMENT_NAME);
     expect(item).toBeDefined();
-    // Should have single variant with null culture
-    expect(item!.variants).toHaveLength(1);
-    expect(item!.variants[0].culture).toBeNull();
+    // Should fetch cultures and create variants (same as when cultures parameter is omitted)
+    // The exact number of variants depends on available cultures in the test environment
+    expect(item!.variants.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/umb-management-api/tools/document/__tests__/create-document.test.ts
+++ b/src/umb-management-api/tools/document/__tests__/create-document.test.ts
@@ -98,8 +98,8 @@ describe("create-document", () => {
     expect(cultures).toEqual(["da-DK", "en-US"]);
   });
 
-  it("should create a document with empty cultures array (auto-fetch behavior)", async () => {
-    // Create document with empty cultures array - should behave same as no cultures parameter
+  it("should create a document with empty cultures array (null culture)", async () => {
+    // Create document with empty cultures array - should behave like original (null culture)
     const docModel = {
       documentTypeId: ROOT_DOCUMENT_TYPE_ID,
       name: TEST_DOCUMENT_NAME,
@@ -115,8 +115,8 @@ describe("create-document", () => {
 
     const item = await DocumentTestHelper.findDocument(TEST_DOCUMENT_NAME);
     expect(item).toBeDefined();
-    // Should fetch cultures and create variants (same as when cultures parameter is omitted)
-    // The exact number of variants depends on available cultures in the test environment
-    expect(item!.variants.length).toBeGreaterThanOrEqual(1);
+    // Should have single variant with null culture (original behavior)
+    expect(item!.variants).toHaveLength(1);
+    expect(item!.variants[0].culture).toBeNull();
   });
 });

--- a/src/umb-management-api/tools/document/__tests__/create-document.test.ts
+++ b/src/umb-management-api/tools/document/__tests__/create-document.test.ts
@@ -74,4 +74,49 @@ describe("create-document", () => {
     };
     expect(norm).toMatchSnapshot();
   });
+
+  it("should create a document with specific cultures", async () => {
+    // Create document with specific cultures
+    const docModel = {
+      documentTypeId: ROOT_DOCUMENT_TYPE_ID,
+      name: TEST_DOCUMENT_NAME,
+      cultures: ["en-US", "da-DK"],
+      values: [],
+    };
+
+    const result = await CreateDocumentTool().handler(docModel, {
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toMatchSnapshot();
+
+    const item = await DocumentTestHelper.findDocument(TEST_DOCUMENT_NAME);
+    expect(item).toBeDefined();
+    // Should have variants for both cultures
+    expect(item!.variants).toHaveLength(2);
+    const cultures = item!.variants.map(v => v.culture).sort();
+    expect(cultures).toEqual(["da-DK", "en-US"]);
+  });
+
+  it("should create a document with empty cultures array (null culture)", async () => {
+    // Create document with empty cultures array - should behave like original
+    const docModel = {
+      documentTypeId: ROOT_DOCUMENT_TYPE_ID,
+      name: TEST_DOCUMENT_NAME,
+      cultures: [],
+      values: [],
+    };
+
+    const result = await CreateDocumentTool().handler(docModel, {
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toMatchSnapshot();
+
+    const item = await DocumentTestHelper.findDocument(TEST_DOCUMENT_NAME);
+    expect(item).toBeDefined();
+    // Should have single variant with null culture
+    expect(item!.variants).toHaveLength(1);
+    expect(item!.variants[0].culture).toBeNull();
+  });
 });

--- a/src/umb-management-api/tools/document/post/create-document.ts
+++ b/src/umb-management-api/tools/document/post/create-document.ts
@@ -10,7 +10,7 @@ const createDocumentSchema = z.object({
   documentTypeId: z.string().uuid("Must be a valid document type type UUID"),
   parentId: z.string().uuid("Must be a valid document UUID").optional(),
   name: z.string(),
-  cultures: z.array(z.string()).optional().describe("Array of culture codes. If not provided, will fetch available cultures from Umbraco. If empty array provided, will create without culture (null culture)."),
+  cultures: z.array(z.string()).optional().describe("Array of culture codes. If not provided, will fetch available cultures from Umbraco."),
   values: z
     .array(
       z.object({
@@ -30,7 +30,6 @@ const CreateDocumentTool = CreateUmbracoTool(
 
   If cultures parameter is provided, a variant will be created for each culture code.
   If cultures parameter is not provided, the tool will automatically fetch available cultures from Umbraco and create variants for all of them.
-  If an empty cultures array is provided, a single variant with null culture will be created (original behavior).
 
   Always follow these requirements when creating documents exactly, do not deviate in any way.
 
@@ -641,8 +640,8 @@ const CreateDocumentTool = CreateUmbracoTool(
     // Determine cultures to use
     let culturesToUse: (string | null)[] = [];
     
-    if (model.cultures === undefined) {
-      // If cultures not provided, fetch available cultures from Umbraco
+    if (model.cultures === undefined || model.cultures.length === 0) {
+      // If cultures not provided or empty array, fetch available cultures from Umbraco
       try {
         const cultureResponse = await client.getCulture({ take: 100 });
         culturesToUse = cultureResponse.items.map(culture => culture.name);
@@ -654,9 +653,6 @@ const CreateDocumentTool = CreateUmbracoTool(
         // If fetching cultures fails, fallback to null culture
         culturesToUse = [null];
       }
-    } else if (model.cultures.length === 0) {
-      // If empty array provided, use null culture (original behavior)
-      culturesToUse = [null];
     } else {
       // Use provided cultures
       culturesToUse = model.cultures;

--- a/src/umb-management-api/tools/document/post/create-document.ts
+++ b/src/umb-management-api/tools/document/post/create-document.ts
@@ -10,7 +10,7 @@ const createDocumentSchema = z.object({
   documentTypeId: z.string().uuid("Must be a valid document type type UUID"),
   parentId: z.string().uuid("Must be a valid document UUID").optional(),
   name: z.string(),
-  cultures: z.array(z.string()).optional().describe("Array of culture codes. If not provided, will fetch available cultures from Umbraco."),
+  cultures: z.array(z.string()).optional().describe("Array of culture codes. If not provided or empty array, will create single variant with null culture."),
   values: z
     .array(
       z.object({
@@ -29,7 +29,7 @@ const CreateDocumentTool = CreateUmbracoTool(
   `Creates a document with support for multiple cultures.
 
   If cultures parameter is provided, a variant will be created for each culture code.
-  If cultures parameter is not provided, the tool will automatically fetch available cultures from Umbraco and create variants for all of them.
+  If cultures parameter is not provided or is an empty array, will create a single variant with null culture (original behavior).
 
   Always follow these requirements when creating documents exactly, do not deviate in any way.
 
@@ -641,18 +641,8 @@ const CreateDocumentTool = CreateUmbracoTool(
     let culturesToUse: (string | null)[] = [];
     
     if (model.cultures === undefined || model.cultures.length === 0) {
-      // If cultures not provided or empty array, fetch available cultures from Umbraco
-      try {
-        const cultureResponse = await client.getCulture({ take: 100 });
-        culturesToUse = cultureResponse.items.map(culture => culture.name);
-        // If no cultures available, fallback to null culture
-        if (culturesToUse.length === 0) {
-          culturesToUse = [null];
-        }
-      } catch (error) {
-        // If fetching cultures fails, fallback to null culture
-        culturesToUse = [null];
-      }
+      // If cultures not provided or empty array, use original behavior (null culture)
+      culturesToUse = [null];
     } else {
       // Use provided cultures
       culturesToUse = model.cultures;


### PR DESCRIPTION
I've used Copilot to implement the missing culture support. I've tested it locally, where I can now correctly create new document in Umbraco with multiple cultures.

Fixes #3 

---

## Problem
The existing implementation hardcoded a single variant with `culture: null`:

```typescript
variants: [
  {
    culture: null,
    name: model.name,
    segment: null,
  },
]
```

This meant documents could only be created in the default culture, making the tool unusable for multi-culture Umbraco sites.

## Solution
Added an optional `cultures` parameter that supports two usage patterns:

1. **Default behavior** (no cultures specified):
   ```typescript
   // No cultures parameter OR empty array - uses original null culture behavior
   {
     documentTypeId: "...",
     name: "My Document",
     values: [...]
   }
   // OR
   {
     documentTypeId: "...",
     name: "My Document",
     cultures: [],
     values: [...]
   }
   ```

2. **Explicit cultures**:
   ```typescript
   // Specify exact cultures to create variants for
   {
     documentTypeId: "...",
     name: "My Document", 
     cultures: ["en-US", "da-DK", "fr-FR"],
     values: [...]
   }
   ```

## Implementation Details
- Creates document variants for each specified culture when cultures array is provided
- Falls back to original null culture behavior when no cultures specified or empty array provided
- Added comprehensive test coverage for all scenarios
- Updated tool description to document the new parameter
- Simple and reliable: only creates multiple variants when explicitly requested

## Backward Compatibility
All existing code continues to work unchanged. When no `cultures` parameter is provided, the tool maintains the original behavior of creating a single variant with null culture, ensuring complete backward compatibility.