### PR TITLE
Improve copy-document tool with flattened schema and clearer workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "patch-publish-alpha": "npm version prerelease --preid=alpha && npm publish --tag alpha --access public",
-    "eval-mcp:basic": "npx mcp-server-tester evals tests/e2e/basic/basic-tests.yaml --server-config tests/e2e/basic/basic-tests-config.json",
-    "eval-mcp:create-data-type": "npx mcp-server-tester evals tests/e2e/create-data-type/create-data-type.yaml --server-config tests/e2e/create-data-type/create-data-type-config.json",
-    "eval-mcp:create-document-type": "npx mcp-server-tester evals tests/e2e/create-document-type/create-document-type.yaml --server-config tests/e2e/create-document-type/create-document-type-config.json",
-    "eval-mcp:create-blog-post": "npx mcp-server-tester evals tests/e2e/create-blog-post/create-blog-post.yaml --server-config tests/e2e/create-blog-post/create-blog-post-config.json",
+    "eval-mcp:basic": "npx mcp-server-tester@1.4.0 evals tests/e2e/basic/basic-tests.yaml --server-config tests/e2e/basic/basic-tests-config.json",
+    "eval-mcp:create-data-type": "npx mcp-server-tester@1.4.0 evals tests/e2e/create-data-type/create-data-type.yaml --server-config tests/e2e/create-data-type/create-data-type-config.json",
+    "eval-mcp:create-document-type": "npx mcp-server-tester@1.4.0 evals tests/e2e/create-document-type/create-document-type.yaml --server-config tests/e2e/create-document-type/create-document-type-config.json",
+    "eval-mcp:create-blog-post": "npx mcp-server-tester@1.4.0 evals tests/e2e/create-blog-post/create-blog-post.yaml --server-config tests/e2e/create-blog-post/create-blog-post-config.json",
     "eval-mcp:all": "npm run eval-mcp:basic && npm run eval-mcp:create-data-type && npm run eval-mcp:create-document-type && npm run eval-mcp:create-blog-post"
   },
   "engines": {

--- a/src/umb-management-api/tools/document/__tests__/copy-document.test.ts
+++ b/src/umb-management-api/tools/document/__tests__/copy-document.test.ts
@@ -34,15 +34,12 @@ describe("copy-document", () => {
       .withRootDocumentType()
       .create();
 
-    // Copy the document to root (no target)
+    // Copy the document to root (no parentId means root)
     const result = await CopyDocumentTool().handler(
       {
-        id: docBuilder.getId(),
-        data: {
-          target: null,
-          relateToOriginal: false,
-          includeDescendants: false,
-        },
+        idToCopy: docBuilder.getId(),
+        relateToOriginal: false,
+        includeDescendants: false,
       },
       { signal: new AbortController().signal }
     );
@@ -73,12 +70,9 @@ describe("copy-document", () => {
   it("should handle non-existent document", async () => {
     const result = await CopyDocumentTool().handler(
       {
-        id: BLANK_UUID,
-        data: {
-          target: null,
-          relateToOriginal: false,
-          includeDescendants: false,
-        },
+        idToCopy: BLANK_UUID,
+        relateToOriginal: false,
+        includeDescendants: false,
       },
       { signal: new AbortController().signal }
     );

--- a/tests/e2e/create-blog-post/create-blog-post-config.json
+++ b/tests/e2e/create-blog-post/create-blog-post-config.json
@@ -7,7 +7,7 @@
           "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
           "UMBRACO_CLIENT_SECRET": "1234567890",
           "UMBRACO_BASE_URL": "http://localhost:56472",
-          "UMBRACO_INCLUDE_TOOLS": "search-document,get-document-by-id,copy-document,publish-document,delete-document,get-document-root,get-document-children,get-document-publish,get-document-type-by-id,get-all-document-types"
+          "UMBRACO_INCLUDE_TOOLS": "get-document-root,get-document-children,get-document-publish,get-document-by-id,copy-document,publish-document,delete-document,update-document"
         }
       }
     }

--- a/tests/e2e/create-blog-post/create-blog-post.yaml
+++ b/tests/e2e/create-blog-post/create-blog-post.yaml
@@ -9,30 +9,31 @@ evals:
     - name: "Create and manage blog post workflow"
       prompt: |
         Complete these tasks in order:
-        1. Copy an existing blog post document and create a new blog post document with the following details:
+        1. Get the root document of umbraco
+        2. Find the Blogs document under the root node
+        3. Copy an existing blog post document
+        4. Update the copied blog post document with the following details:
            - Title: "_Test Blog Post - Creating Amazing Content"
            - Content/Body: A rich text content about creating amazing content for blogs
            - Author: "Paul Seal"
-        2. Publish the blog post
-        3. Delete the blog post
-        4. When successfully completed all tasks, say 'The blog post workflow has completed successfully', nothing else
+        5. Publish the blog post
+        6. Delete the blog post
+        7. When successfully completed all tasks, say 'The blog post workflow has completed successfully', nothing else
       expected_tool_calls:
         required:
-          - "search-document"
           - "copy-document"
           - "get-document-by-id"
+          - "update-document"
           - "publish-document"
           - "delete-document"
         allowed:
-          - "search-document"
           - "get-document-root"
           - "get-document-children"
           - "get-document-by-id"
           - "copy-document"
           - "publish-document"
-          - "get-document-publish"
           - "delete-document"
-          - "get-document-type-by-id"
+          - "update-document"
       response_scorers:
         - type: 'llm-judge'
           criteria: 'Did the last assistant step say "The blog post workflow has completed successfully"'


### PR DESCRIPTION
## Summary
- Simplifies copy-document tool parameter structure for better LLM usability
- Adds comprehensive workflow documentation with clear examples
- Updates e2e test to use simpler copy → update → publish workflow
- Pins mcp-server-tester version for consistency

## Key Changes

### Tool Parameter Schema
- **Flattened structure**: Replaced nested `{id, data: {...}}` with top-level parameters
- **Clearer naming**: `id` → `idToCopy` for better semantic meaning
- **Optional parent**: `parentId` is optional (omit for root, provide for specific parent)
- **Direct access**: `relateToOriginal` and `includeDescendants` at top level

**Before:**
```typescript
{
  id: "document-uuid",
  data: {
    target: null,
    relateToOriginal: false,
    includeDescendants: false
  }
}
```

**After:**
```typescript
{
  idToCopy: "document-uuid",
  relateToOriginal: false,
  includeDescendants: false
  // parentId: "parent-uuid" (optional)
}
```

### Enhanced Documentation
- Documents the empty string return value behavior
- Provides clear workflow patterns:
  - Copy only: `copy-document` (creates draft)
  - Copy and update: `copy-document` → `search-document` → `update-document` → `publish-document`
- Explains why search-document is needed for post-copy operations

### E2E Test Improvements
- Simplified create-blog-post workflow to use `update-document` directly
- Removed unnecessary `search-document` and document-type lookups
- Updated workflow: `copy` → `update` → `publish` → `delete`
- Cleaned up allowed tools list to match actual workflow needs

### Other Changes
- Pin mcp-server-tester to version 1.4.0 for consistency
- Update copy-document unit tests to match new schema

## Test plan
- [x] TypeScript compilation passes
- [x] Unit tests updated and pass
- [ ] E2E test: create-blog-post workflow
- [ ] Manual test: Copy document to root (no parentId)
- [ ] Manual test: Copy document to specific parent (with parentId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)