### PR TITLE
Fix async getServerConfig call from SDK update

### DIFF
--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -71,12 +71,12 @@ let cachedConfig: ServerConfig | null = null;
  * @param isStdioMode - Whether the server is running in stdio mode (suppresses logging)
  * @returns Combined base and custom configuration
  */
-export function loadServerConfig(isStdioMode: boolean): ServerConfig {
+export async function loadServerConfig(isStdioMode: boolean): Promise<ServerConfig> {
   if (cachedConfig) {
     return cachedConfig;
   }
 
-  const { config, custom } = getServerConfig(isStdioMode, {
+  const { config, custom } = await getServerConfig(isStdioMode, {
     additionalFields: customFields,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const main = async () => {
   clearConfigCache();
 
   // Load and validate configuration
-  const serverConfig = loadServerConfig(true); // true = stdio mode (no logging)
+  const serverConfig = await loadServerConfig(true); // true = stdio mode (no logging)
   const config = serverConfig.umbraco;
 
   // Initialize fetch client with configuration


### PR DESCRIPTION
## Summary
- SDK's `getServerConfig` was updated to return a `Promise`, but `loadServerConfig` was calling it synchronously
- This caused the server to crash on startup (destructuring a Promise gives `undefined` for config values)
- Made `loadServerConfig` async and added `await` at the call site

## Test plan
- [x] TypeScript compiles cleanly
- [x] MCP server starts and responds to initialize request
- [ ] Eval tests pass with Umbraco running

🤖 Generated with [Claude Code](https://claude.com/claude-code)