### PR TITLE
Fix remaining async SDK changes and update snapshots

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -28,7 +28,7 @@ const config: import("ts-jest").JestConfigWithTsJest = {
     ],
   },
   testMatch: ["**/src/**/__tests__/**/*.test.ts", "**/tests/evals/**/*.test.ts"],
-  testPathIgnorePatterns: ["/node_modules/"],
+  testPathIgnorePatterns: ["/node_modules/", "\\.claude/worktrees/"],
   setupFilesAfterEnv: ["jest-extended/all"],
   setupFiles: ["<rootDir>/jest.setup.ts"],
   maxConcurrency: 1, // Umbraco uses SQLite which doesn't support concurrent connections

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
@@ -5,9 +5,9 @@ exports[`publish-document-with-descendants should handle publishing a non-existe
   "content": [],
   "isError": true,
   "structuredContent": {
-    "detail": "Request failed with status code 404",
+    "detail": "Request failed with status 404: Not Found",
     "status": 500,
-    "title": "AxiosError",
+    "title": "Error",
     "type": "Error",
   },
 }

--- a/src/umb-management-api/tools/media/__tests__/helpers/validate-file-path.test.ts
+++ b/src/umb-management-api/tools/media/__tests__/helpers/validate-file-path.test.ts
@@ -49,67 +49,67 @@ describe("validate-file-path", () => {
   });
 
   describe("when UMBRACO_ALLOWED_MEDIA_PATHS is not configured", () => {
-    it("should reject all file path uploads with clear error message", () => {
-      expect(() => validateFilePath(testFile, undefined)).toThrow(
+    it("should reject all file path uploads with clear error message", async () => {
+      await expect(validateFilePath(testFile, undefined)).rejects.toThrow(
         "File path uploads are disabled. To enable, set UMBRACO_ALLOWED_MEDIA_PATHS environment variable"
       );
     });
   });
 
   describe("when UMBRACO_ALLOWED_MEDIA_PATHS is empty array", () => {
-    it("should reject all file path uploads", () => {
-      expect(() => validateFilePath(testFile, [])).toThrow(
+    it("should reject all file path uploads", async () => {
+      await expect(validateFilePath(testFile, [])).rejects.toThrow(
         "File path uploads are disabled"
       );
     });
   });
 
   describe("when UMBRACO_ALLOWED_MEDIA_PATHS is configured", () => {
-    it("should allow files within allowed directory", () => {
-      const result = validateFilePath(testFile, [tempDir]);
+    it("should allow files within allowed directory", async () => {
+      const result = await validateFilePath(testFile, [tempDir]);
       expect(result).toBe(path.resolve(testFile));
     });
 
-    it("should reject files outside allowed directories", () => {
-      expect(() => validateFilePath(outsideFile, [tempDir])).toThrow(
+    it("should reject files outside allowed directories", async () => {
+      await expect(validateFilePath(outsideFile, [tempDir])).rejects.toThrow(
         `File path "${outsideFile}" is not in an allowed directory`
       );
     });
 
-    it("should prevent path traversal attacks", () => {
+    it("should prevent path traversal attacks", async () => {
       const traversalPath = path.join(tempDir, "..", "..", "etc", "passwd");
-      expect(() => validateFilePath(traversalPath, [tempDir])).toThrow(
+      await expect(validateFilePath(traversalPath, [tempDir])).rejects.toThrow(
         "is not in an allowed directory"
       );
     });
 
-    it("should reject non-existent files", () => {
+    it("should reject non-existent files", async () => {
       const nonExistent = path.join(tempDir, "nonexistent.jpg");
-      expect(() => validateFilePath(nonExistent, [tempDir])).toThrow(
+      await expect(validateFilePath(nonExistent, [tempDir])).rejects.toThrow(
         "File not found"
       );
     });
 
-    it("should normalize relative paths before validation", () => {
+    it("should normalize relative paths before validation", async () => {
       const relativePath = path.relative(process.cwd(), testFile);
-      const result = validateFilePath(relativePath, [tempDir]);
+      const result = await validateFilePath(relativePath, [tempDir]);
       expect(result).toBe(path.resolve(testFile));
     });
   });
 
   describe("symlink handling", () => {
-    it("should allow symlinks pointing to files within allowed directories", () => {
+    it("should allow symlinks pointing to files within allowed directories", async () => {
       fs.symlinkSync(testFile, testSymlink);
-      const result = validateFilePath(testSymlink, [tempDir]);
+      const result = await validateFilePath(testSymlink, [tempDir]);
       expect(result).toBe(path.resolve(testSymlink));
     });
 
-    it("should reject symlinks pointing to files outside allowed directories", () => {
+    it("should reject symlinks pointing to files outside allowed directories", async () => {
       fs.symlinkSync(outsideFile, testSymlink);
-      expect(() => validateFilePath(testSymlink, [tempDir])).toThrow(
+      await expect(validateFilePath(testSymlink, [tempDir])).rejects.toThrow(
         "is a symbolic link to"
       );
-      expect(() => validateFilePath(testSymlink, [tempDir])).toThrow(
+      await expect(validateFilePath(testSymlink, [tempDir])).rejects.toThrow(
         "which is outside allowed directories"
       );
     });
@@ -134,18 +134,18 @@ describe("validate-file-path", () => {
       }
     });
 
-    it("should allow files from first allowed directory", () => {
-      const result = validateFilePath(testFile, [tempDir, secondTempDir]);
+    it("should allow files from first allowed directory", async () => {
+      const result = await validateFilePath(testFile, [tempDir, secondTempDir]);
       expect(result).toBe(path.resolve(testFile));
     });
 
-    it("should allow files from second allowed directory", () => {
-      const result = validateFilePath(secondTestFile, [tempDir, secondTempDir]);
+    it("should allow files from second allowed directory", async () => {
+      const result = await validateFilePath(secondTestFile, [tempDir, secondTempDir]);
       expect(result).toBe(path.resolve(secondTestFile));
     });
 
-    it("should reject files outside all allowed directories", () => {
-      expect(() => validateFilePath(outsideFile, [tempDir, secondTempDir])).toThrow(
+    it("should reject files outside all allowed directories", async () => {
+      await expect(validateFilePath(outsideFile, [tempDir, secondTempDir])).rejects.toThrow(
         "is not in an allowed directory"
       );
     });

--- a/src/umb-management-api/tools/media/post/helpers/media-upload-helpers.ts
+++ b/src/umb-management-api/tools/media/post/helpers/media-upload-helpers.ts
@@ -145,7 +145,7 @@ export async function createFileStream(
         throw new Error("filePath is required when sourceType is 'filePath'");
       }
       // Validate file path is within allowed directories (security check)
-      const validatedPath = validateFilePath(filePath);
+      const validatedPath = await validateFilePath(filePath);
       readStream = fs.createReadStream(validatedPath);
       break;
 

--- a/src/umb-management-api/tools/media/post/helpers/validate-file-path.ts
+++ b/src/umb-management-api/tools/media/post/helpers/validate-file-path.ts
@@ -7,9 +7,9 @@ import { getServerConfig } from "@umbraco-cms/mcp-server-sdk";
  * Prevents path traversal attacks and validates symlink targets.
  * Exported for testing.
  */
-export function validateFilePath(filePath: string, allowedPaths?: string[]): string {
+export async function validateFilePath(filePath: string, allowedPaths?: string[]): Promise<string> {
   // Get configuration (in stdio mode, this won't log) or use provided paths
-  const allowedMediaPaths = allowedPaths ?? getServerConfig(true).config.allowedMediaPaths;
+  const allowedMediaPaths = allowedPaths ?? (await getServerConfig(true)).config.allowedMediaPaths;
 
   // Check if UMBRACO_ALLOWED_MEDIA_PATHS is configured
   if (!allowedMediaPaths || allowedMediaPaths.length === 0) {

--- a/src/umb-management-api/tools/user-group/__tests__/__snapshots__/create-user-group.test.ts.snap
+++ b/src/umb-management-api/tools/user-group/__tests__/__snapshots__/create-user-group.test.ts.snap
@@ -17,6 +17,7 @@ exports[`create-user-group should create a user group 2`] = `
       {
         "alias": "testUserGroupCreated",
         "aliasCanBeChanged": true,
+        "description": "",
         "documentRootAccess": false,
         "documentStartNode": null,
         "fallbackPermissions": [],

--- a/src/umb-management-api/tools/user-group/__tests__/__snapshots__/update-user-group.test.ts.snap
+++ b/src/umb-management-api/tools/user-group/__tests__/__snapshots__/update-user-group.test.ts.snap
@@ -31,6 +31,7 @@ exports[`update-user-group should update a user group 2`] = `
       {
         "alias": "updatedUserGroup",
         "aliasCanBeChanged": true,
+        "description": "",
         "documentRootAccess": false,
         "documentStartNode": null,
         "fallbackPermissions": [],


### PR DESCRIPTION
## Summary
- Made `validateFilePath` async to properly await `getServerConfig`
- Updated all validate-file-path tests for async/await pattern
- Added `.claude/worktrees/` to jest ignore paths
- Updated snapshots for SDK error format changes and new user-group `description` field

## Test plan
- [x] TypeScript compiles cleanly
- [ ] validate-file-path tests pass
- [ ] user-group tests pass with updated snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)