### PR TITLE
Fix Umbraco MCP documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Download and install the [Claude Desktop app](https://claude.ai/download), then 
 
 For complete installation instructions, configuration options, tool listings, and usage examples, see the full documentation:
 
-**[Umbraco MCP Documentation](https://docs.umbraco.com/umbraco-cms/reference/developer-mcp)**
+**[Umbraco MCP Documentation](https://docs.umbraco.com/umbraco-developer-mcp)**
 
 ## Contributing with AI Tools
 


### PR DESCRIPTION
## Summary
Updated the documentation link in the README to point to the correct Umbraco MCP documentation URL.

## Changes
- Updated the Umbraco MCP documentation link from `https://docs.umbraco.com/umbraco-cms/reference/developer-mcp` to `https://docs.umbraco.com/umbraco-developer-mcp`

## Details
The documentation URL path has been corrected to match the actual location of the Umbraco MCP documentation. This ensures users are directed to the correct documentation resource when following the link in the README.

https://claude.ai/code/session_01SA22Fn1wuoZZgNcehQYgAP