### PR TITLE
feat: add outputSchema to mutation tools, bump SDK to beta.18

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { initializeUmbracoAxios, configureApiClient } from '@umbraco-cms/mcp-server-sdk';
+import { initializeUmbracoFetch, configureApiClient } from '@umbraco-cms/mcp-server-sdk';
 import { UmbracoManagementClient } from './src/umb-management-api/umbraco-management-client.js';
 import { resolve } from 'path';
 
@@ -12,8 +12,8 @@ if (!process.env.UMBRACO_ALLOWED_MEDIA_PATHS) {
   process.env.UMBRACO_ALLOWED_MEDIA_PATHS = resolve(process.cwd());
 }
 
-// Initialize Umbraco Axios client with environment variables
-initializeUmbracoAxios({
+// Initialize Umbraco fetch client with environment variables
+initializeUmbracoFetch({
   clientId: process.env.UMBRACO_CLIENT_ID || '',
   clientSecret: process.env.UMBRACO_CLIENT_SECRET || '',
   baseUrl: process.env.UMBRACO_BASE_URL || ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/uuid": "^10.0.0",
         "@types/yargs": "^17.0.33",
         "@umbraco-cms/mcp-hosted": "^17.0.0-beta.16",
-        "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.16",
+        "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.18",
         "axios": "^1.8.4",
         "dotenv": "^16.5.0",
         "form-data": "^4.0.4",
@@ -3796,10 +3796,35 @@
         }
       }
     },
-    "node_modules/@umbraco-cms/mcp-server-sdk": {
+    "node_modules/@umbraco-cms/mcp-hosted/node_modules/@umbraco-cms/mcp-server-sdk": {
       "version": "17.0.0-beta.16",
       "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-server-sdk/-/mcp-server-sdk-17.0.0-beta.16.tgz",
       "integrity": "sha512-IkNobjB7sR8Mm8i5vCbHwM8bFJOYWbU0LoGaGBvDGrH9iN2efE5k23/BC2DTDvg6yb5P/hjCE1Bi8dao3bkQig==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.28.0",
+        "json-schema-to-typescript": "^15.0.4",
+        "zod": "^4.2.1"
+      },
+      "bin": {
+        "umbraco-mcp-generate-types": "dist/cli/generate-tool-types.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/claude-agent-sdk": ">=0.2.39"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@umbraco-cms/mcp-server-sdk": {
+      "version": "17.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-server-sdk/-/mcp-server-sdk-17.0.0-beta.18.tgz",
+      "integrity": "sha512-t1ONxmczSPATmRVWy9YoxsEzVc/yeLoNBdoTl4gFlm4+yGX8Wiu60S6CmemyKQ9yi8aZP3tNiQo6dfPOuWQW3Q==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/uuid": "^10.0.0",
     "@types/yargs": "^17.0.33",
     "@umbraco-cms/mcp-hosted": "^17.0.0-beta.16",
-    "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.16",
+    "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.18",
     "axios": "^1.8.4",
     "dotenv": "^16.5.0",
     "form-data": "^4.0.4",

--- a/src/umb-management-api/tools/__tests__/output-schema-validation.test.ts
+++ b/src/umb-management-api/tools/__tests__/output-schema-validation.test.ts
@@ -85,8 +85,9 @@ describe("outputSchema validation for all tools", () => {
   it.each(toolsWithOutputSchema)(
     "%s: outputSchema values must all be ZodType instances",
     (_name, tool) => {
+      // Empty shapes (z.object({}).shape === {}) are valid — used by void mutation tools
+      // that declare outputSchema solely to surface `output: {}` in the type registry.
       const entries = Object.entries(tool.outputSchema as Record<string, unknown>);
-      expect(entries.length).toBeGreaterThan(0);
 
       for (const [key, value] of entries) {
         if (!(value instanceof z.ZodType)) {

--- a/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/move-dictionary-item.test.ts.snap
+++ b/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/move-dictionary-item.test.ts.snap
@@ -13,3 +13,27 @@ exports[`move-dictionary-item should handle non-existent dictionary item 1`] = `
 }
 `;
 
+
+exports[`move-dictionary-item should move a dictionary item to a new parent 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;
+
+exports[`move-dictionary-item should move a dictionary item from parent back to root 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/move-dictionary-item.test.ts.snap
+++ b/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/move-dictionary-item.test.ts.snap
@@ -13,24 +13,3 @@ exports[`move-dictionary-item should handle non-existent dictionary item 1`] = `
 }
 `;
 
-exports[`move-dictionary-item should move a dictionary item from parent back to root 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
-exports[`move-dictionary-item should move a dictionary item to a new parent 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/update-dictionary-item.test.ts.snap
+++ b/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/update-dictionary-item.test.ts.snap
@@ -13,17 +13,6 @@ exports[`update-dictionary-item should handle non-existent dictionary item 1`] =
 }
 `;
 
-exports[`update-dictionary-item should update a dictionary item 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`update-dictionary-item should update a dictionary item 2`] = `
 [
   {

--- a/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/update-dictionary-item.test.ts.snap
+++ b/src/umb-management-api/tools/dictionary/__tests__/__snapshots__/update-dictionary-item.test.ts.snap
@@ -25,3 +25,15 @@ exports[`update-dictionary-item should update a dictionary item 2`] = `
   },
 ]
 `;
+
+exports[`update-dictionary-item should update a dictionary item 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/dictionary/put/move-dictionary-item.ts
+++ b/src/umb-management-api/tools/dictionary/put/move-dictionary-item.ts
@@ -7,9 +7,13 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const moveDictionaryItemSchema = {
   id: putDictionaryByIdMoveParams.shape.id,
@@ -20,15 +24,16 @@ const MoveDictionaryItemTool = {
   name: "move-dictionary-item",
   description: "Moves a dictionary item by Id",
   inputSchema: moveDictionaryItemSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['move'],
   handler: (async (model: { id: string; data: MoveDictionaryRequestModel }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDictionaryByIdMove(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof moveDictionaryItemSchema>;
+} satisfies ToolDefinition<typeof moveDictionaryItemSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(MoveDictionaryItemTool);

--- a/src/umb-management-api/tools/dictionary/put/update-dictionary-item.ts
+++ b/src/umb-management-api/tools/dictionary/put/update-dictionary-item.ts
@@ -7,9 +7,13 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const updateDictionaryItemSchema = {
   id: putDictionaryByIdParams.shape.id,
@@ -20,15 +24,16 @@ const UpdateDictionaryItemTool = {
   name: "update-dictionary-item",
   description: "Updates a dictionary item by Id",
   inputSchema: updateDictionaryItemSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['update'],
   handler: (async (model: { id: string; data: UpdateDictionaryItemRequestModel }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDictionaryById(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof updateDictionaryItemSchema>;
+} satisfies ToolDefinition<typeof updateDictionaryItemSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(UpdateDictionaryItemTool);

--- a/src/umb-management-api/tools/document-blueprint/__tests__/__snapshots__/create-document-blueprint-from-document.test.ts.snap
+++ b/src/umb-management-api/tools/document-blueprint/__tests__/__snapshots__/create-document-blueprint-from-document.test.ts.snap
@@ -26,3 +26,12 @@ exports[`create-document-blueprint-from-document should handle non-existent sour
   },
 }
 `;
+
+exports[`create-document-blueprint-from-document should create document blueprint from existing document 1`] = `
+{
+  "content": [],
+  "structuredContent": {
+    "id": "00000000-0000-0000-0000-000000000000",
+  },
+}
+`;

--- a/src/umb-management-api/tools/document-blueprint/__tests__/__snapshots__/create-document-blueprint-from-document.test.ts.snap
+++ b/src/umb-management-api/tools/document-blueprint/__tests__/__snapshots__/create-document-blueprint-from-document.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`create-document-blueprint-from-document should create document blueprint from existing document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`create-document-blueprint-from-document should handle duplicate blueprint name 1`] = `
 {
   "content": [],

--- a/src/umb-management-api/tools/document-blueprint/post/create-document-blueprint-from-document.ts
+++ b/src/umb-management-api/tools/document-blueprint/post/create-document-blueprint-from-document.ts
@@ -1,10 +1,12 @@
-import { CreateDocumentBlueprintFromDocumentRequestModel, CurrentUserResponseModel } from "@/umb-management-api/schemas/index.js";
+import { UmbracoManagementClient } from "@umb-management-client";
+import { CreateDocumentBlueprintFromDocumentRequestModel, CurrentUserResponseModel, ProblemDetails } from "@/umb-management-api/schemas/index.js";
 import { z } from "zod";
 import {
   type ToolDefinition,
-  CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
+  createToolResult,
+  createToolResultError,
   withStandardDecorators,
+  type HttpResponse,
 } from "@umbraco-cms/mcp-server-sdk";
 
 // Note: The Umbraco API schema includes a 'parent' parameter, but testing shows it is not
@@ -18,6 +20,10 @@ const createDocumentBlueprintFromDocumentSchema = z.object({
   name: z.string()
 });
 
+export const createDocumentBlueprintFromDocumentOutputSchema = z.object({
+  id: z.string().guid()
+});
+
 type CreateDocumentBlueprintFromDocumentModel = z.infer<typeof createDocumentBlueprintFromDocumentSchema>;
 
 const CreateDocumentBlueprintFromDocumentTool = {
@@ -27,6 +33,7 @@ const CreateDocumentBlueprintFromDocumentTool = {
 
   Note: Blueprints created from documents are always created at the root level. Use the move-document-blueprint tool to relocate them to folders after creation if needed.`,
   inputSchema: createDocumentBlueprintFromDocumentSchema.shape,
+  outputSchema: createDocumentBlueprintFromDocumentOutputSchema.shape,
   slices: ['create'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes("Umb.Document.CreateBlueprint"),
   handler: (async (model: CreateDocumentBlueprintFromDocumentModel) => {
@@ -37,10 +44,30 @@ const CreateDocumentBlueprintFromDocumentTool = {
       parent: undefined,
     };
 
-    return executeVoidApiCall((client) =>
-      client.postDocumentBlueprintFromDocument(payload, CAPTURE_RAW_HTTP_RESPONSE)
-    );
+    const client = UmbracoManagementClient.getClient();
+    const response = await client.postDocumentBlueprintFromDocument(payload, {
+      returnFullResponse: true,
+      validateStatus: () => true,
+    }) as unknown as HttpResponse<ProblemDetails | void>;
+
+    if (response.status >= 200 && response.status < 300) {
+      const locationHeader = response.headers?.['location'] || response.headers?.['Location'];
+      let createdId = model.id ?? '';
+      if (locationHeader) {
+        const idMatch = locationHeader.match(/document-blueprint\/([a-f0-9-]+)$/i);
+        if (idMatch) {
+          createdId = idMatch[1];
+        }
+      }
+      return createToolResult({ id: createdId });
+    }
+
+    const errorData: ProblemDetails = response.data || {
+      status: response.status,
+      detail: response.statusText,
+    };
+    return createToolResultError(errorData);
   }),
-} satisfies ToolDefinition<typeof createDocumentBlueprintFromDocumentSchema.shape>;
+} satisfies ToolDefinition<typeof createDocumentBlueprintFromDocumentSchema.shape, typeof createDocumentBlueprintFromDocumentOutputSchema.shape>;
 
 export default withStandardDecorators(CreateDocumentBlueprintFromDocumentTool);

--- a/src/umb-management-api/tools/document-version/__tests__/__snapshots__/create-document-version-rollback.test.ts.snap
+++ b/src/umb-management-api/tools/document-version/__tests__/__snapshots__/create-document-version-rollback.test.ts.snap
@@ -11,3 +11,27 @@ exports[`create-document-version-rollback should handle non-existent version ID 
 }
 `;
 
+
+exports[`create-document-version-rollback should rollback document to a specific version 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;
+
+exports[`create-document-version-rollback should rollback document to a specific version with culture 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document-version/__tests__/__snapshots__/create-document-version-rollback.test.ts.snap
+++ b/src/umb-management-api/tools/document-version/__tests__/__snapshots__/create-document-version-rollback.test.ts.snap
@@ -11,24 +11,3 @@ exports[`create-document-version-rollback should handle non-existent version ID 
 }
 `;
 
-exports[`create-document-version-rollback should rollback document to a specific version 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
-exports[`create-document-version-rollback should rollback document to a specific version with culture 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document-version/post/create-document-version-rollback.ts
+++ b/src/umb-management-api/tools/document-version/post/create-document-version-rollback.ts
@@ -2,9 +2,13 @@ import { postDocumentVersionByIdRollbackParams, postDocumentVersionByIdRollbackQ
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 // Combined schema for both path params and query params
 const createDocumentVersionRollbackSchema = postDocumentVersionByIdRollbackParams.merge(
@@ -15,12 +19,13 @@ const CreateDocumentVersionRollbackTool = {
   name: "create-document-version-rollback",
   description: "Rollback document to a specific version",
   inputSchema: createDocumentVersionRollbackSchema.shape,
+  outputSchema: emptyOutputShape,
   slices: ['create'],
   handler: (async ({ id, culture }: { id: string; culture?: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.postDocumentVersionByIdRollback(id, { culture }, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof createDocumentVersionRollbackSchema.shape>;
+} satisfies ToolDefinition<typeof createDocumentVersionRollbackSchema.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(CreateDocumentVersionRollbackTool);

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/move-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/move-document.test.ts.snap
@@ -26,3 +26,15 @@ exports[`move-document should handle moving to non-existent target 1`] = `
 }
 `;
 
+
+exports[`move-document should move a document to another root document 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/move-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/move-document.test.ts.snap
@@ -26,13 +26,3 @@ exports[`move-document should handle moving to non-existent target 1`] = `
 }
 `;
 
-exports[`move-document should move a document to another root document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
@@ -13,13 +13,3 @@ exports[`move-document-to-recycle-bin should handle moving a non-existent docume
 }
 `;
 
-exports[`move-document-to-recycle-bin should move a document to the recycle bin 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
@@ -13,3 +13,15 @@ exports[`move-document-to-recycle-bin should handle moving a non-existent docume
 }
 `;
 
+
+exports[`move-document-to-recycle-bin should move a document to the recycle bin 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/post-document-public-access.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/post-document-public-access.test.ts.snap
@@ -32,3 +32,15 @@ exports[`post-document-public-access should handle non-existent document 1`] = `
   },
 }
 `;
+
+exports[`post-document-public-access should add public access for a valid document using the post tool 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/post-document-public-access.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/post-document-public-access.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`post-document-public-access should add public access for a valid document using the post tool 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`post-document-public-access should add public access for a valid document using the post tool 2`] = `
 {
   "errorDocument": {

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
@@ -13,3 +13,15 @@ exports[`publish-document-with-descendants should handle publishing a non-existe
 }
 `;
 
+
+exports[`publish-document-with-descendants should publish a document and its descendants 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
@@ -13,13 +13,3 @@ exports[`publish-document-with-descendants should handle publishing a non-existe
 }
 `;
 
-exports[`publish-document-with-descendants should publish a document and its descendants 1`] = `
-{
-  "content": [
-    {
-      "text": """",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document-with-descendants.test.ts.snap
@@ -18,7 +18,7 @@ exports[`publish-document-with-descendants should publish a document and its des
 {
   "content": [
     {
-      "text": "",
+      "text": """",
       "type": "text",
     },
   ],

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document.test.ts.snap
@@ -13,3 +13,15 @@ exports[`publish-document should handle publishing a non-existent document 1`] =
 }
 `;
 
+
+exports[`publish-document should publish a valid document 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/publish-document.test.ts.snap
@@ -13,13 +13,3 @@ exports[`publish-document should handle publishing a non-existent document 1`] =
 }
 `;
 
-exports[`publish-document should publish a valid document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-notifications.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-notifications.test.ts.snap
@@ -77,3 +77,15 @@ exports[`put-document-notifications should handle non-existent document 1`] = `
   },
 }
 `;
+
+exports[`put-document-notifications should add a notification for a valid document 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-notifications.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-notifications.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`put-document-notifications should add a notification for a valid document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`put-document-notifications should add a notification for a valid document 2`] = `
 {
   "content": [],

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-public-access.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-public-access.test.ts.snap
@@ -32,3 +32,15 @@ exports[`put-document-public-access should update public access for a valid docu
   "members": [],
 }
 `;
+
+exports[`put-document-public-access should update public access for a valid document 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-public-access.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/put-document-public-access.test.ts.snap
@@ -13,17 +13,6 @@ exports[`put-document-public-access should handle non-existent document 1`] = `
 }
 `;
 
-exports[`put-document-public-access should update public access for a valid document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`put-document-public-access should update public access for a valid document 2`] = `
 {
   "errorDocument": {

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/sort-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/sort-document.test.ts.snap
@@ -1,2 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+
+exports[`sort-document should sort children under a root document 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/sort-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/sort-document.test.ts.snap
@@ -1,12 +1,2 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sort-document should sort children under a root document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/unpublish-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/unpublish-document.test.ts.snap
@@ -13,13 +13,3 @@ exports[`unpublish-document should handle unpublishing a non-existent document 1
 }
 `;
 
-exports[`unpublish-document should unpublish a published document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/unpublish-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/unpublish-document.test.ts.snap
@@ -13,3 +13,15 @@ exports[`unpublish-document should handle unpublishing a non-existent document 1
 }
 `;
 
+
+exports[`unpublish-document should unpublish a published document 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/update-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/update-document.test.ts.snap
@@ -13,24 +13,3 @@ exports[`update-document should handle non-existent document 1`] = `
 }
 `;
 
-exports[`update-document should update a document 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
-exports[`update-document should update document with properties 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/update-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/update-document.test.ts.snap
@@ -13,3 +13,27 @@ exports[`update-document should handle non-existent document 1`] = `
 }
 `;
 
+
+exports[`update-document should update a document 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;
+
+exports[`update-document should update document with properties 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/document/delete/delete-document-public-access.ts
+++ b/src/umb-management-api/tools/document/delete/delete-document-public-access.ts
@@ -4,24 +4,29 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const DeleteDocumentPublicAccessTool = {
   name: "delete-document-public-access",
   description: "Removes public access settings from a document by Id.",
   inputSchema: deleteDocumentByIdPublicAccessParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     destructiveHint: true,
   },
   slices: ['public-access'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.PublicAccess),
   handler: (async ({ id }: { id: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.deleteDocumentByIdPublicAccess(id, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof deleteDocumentByIdPublicAccessParams.shape>;
+} satisfies ToolDefinition<typeof deleteDocumentByIdPublicAccessParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(DeleteDocumentPublicAccessTool);

--- a/src/umb-management-api/tools/document/post/post-document-public-access.ts
+++ b/src/umb-management-api/tools/document/post/post-document-public-access.ts
@@ -8,9 +8,13 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: postDocumentByIdPublicAccessParams.shape.id,
@@ -21,13 +25,14 @@ const PostDocumentPublicAccessTool = {
   name: "post-document-public-access",
   description: "Adds public access settings to a document by Id.",
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   slices: ['public-access'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.PublicAccess),
   handler: (async (model: { id: string; data: any }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.postDocumentByIdPublicAccess(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(PostDocumentPublicAccessTool);

--- a/src/umb-management-api/tools/document/put/move-document.ts
+++ b/src/umb-management-api/tools/document/put/move-document.ts
@@ -5,9 +5,13 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: z.string().uuid(),
@@ -18,14 +22,15 @@ const MoveDocumentTool = {
   name: "move-document",
   description: "Move a document to a new location",
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {},
   slices: ['move'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Move),
   handler: (async (model: { id: string; data: any }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentByIdMove(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(MoveDocumentTool);

--- a/src/umb-management-api/tools/document/put/move-to-recycle-bin.ts
+++ b/src/umb-management-api/tools/document/put/move-to-recycle-bin.ts
@@ -4,22 +4,27 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const MoveDocumentToRecycleBinTool = {
   name: "move-document-to-recycle-bin",
   description: "Move a document to the recycle bin",
   inputSchema: putDocumentByIdMoveToRecycleBinParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {},
   slices: ['move', 'recycle-bin'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Delete),
   handler: (async ({ id }: { id: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentByIdMoveToRecycleBin(id, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof putDocumentByIdMoveToRecycleBinParams.shape>;
+} satisfies ToolDefinition<typeof putDocumentByIdMoveToRecycleBinParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(MoveDocumentToRecycleBinTool);

--- a/src/umb-management-api/tools/document/put/publish-document-with-descendants.ts
+++ b/src/umb-management-api/tools/document/put/publish-document-with-descendants.ts
@@ -7,6 +7,10 @@ import {
   type ToolDefinition,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: z.string().uuid(),
@@ -18,6 +22,7 @@ const PublishDocumentWithDescendantsTool = {
   description: `Publishes a document and its descendants by Id. This is an asynchronous operation that may take time for large document trees.
   The tool will poll for completion and return the final result when finished.`,
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {},
   slices: ['publish'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Publish),
@@ -39,6 +44,7 @@ const PublishDocumentWithDescendantsTool = {
             text: "\"\"",
           },
         ],
+        structuredContent: {},
       };
     }
 
@@ -67,6 +73,7 @@ const PublishDocumentWithDescendantsTool = {
                 text: "\"\"",
               },
             ],
+            structuredContent: {},
           };
         }
       } catch (error) {
@@ -82,6 +89,7 @@ const PublishDocumentWithDescendantsTool = {
               }),
             },
           ],
+          isError: true,
         };
       }
     }
@@ -98,8 +106,9 @@ const PublishDocumentWithDescendantsTool = {
           }),
         },
       ],
+      isError: true,
     };
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(PublishDocumentWithDescendantsTool);

--- a/src/umb-management-api/tools/document/put/publish-document.ts
+++ b/src/umb-management-api/tools/document/put/publish-document.ts
@@ -5,9 +5,13 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: z.string().uuid(),
@@ -21,6 +25,7 @@ const PublishDocumentTool = {
   When the culture is not provided, the default culture is null.
   When the schedule is not provided, the default schedule is null.`,
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {},
   slices: ['publish'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Publish),
@@ -30,10 +35,10 @@ const PublishDocumentTool = {
       model.data.publishSchedules = [{ culture: null }];
     }
 
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentByIdPublish(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(PublishDocumentTool);

--- a/src/umb-management-api/tools/document/put/put-document-notifications.ts
+++ b/src/umb-management-api/tools/document/put/put-document-notifications.ts
@@ -6,9 +6,13 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: putDocumentByIdNotificationsParams.shape.id,
@@ -19,15 +23,16 @@ const PutDocumentNotificationsTool = {
   name: "put-document-notifications",
   description: "Updates the notifications for a document by Id.",
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['notifications'],
   handler: (async (model: { id: string; data: any }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentByIdNotifications(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(PutDocumentNotificationsTool);

--- a/src/umb-management-api/tools/document/put/put-document-public-access.ts
+++ b/src/umb-management-api/tools/document/put/put-document-public-access.ts
@@ -8,9 +8,13 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: putDocumentByIdPublicAccessParams.shape.id,
@@ -21,16 +25,17 @@ const PutDocumentPublicAccessTool = {
   name: "put-document-public-access",
   description: "Updates public access settings for a document by Id.",
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['public-access'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.PublicAccess),
   handler: (async (model: { id: string; data: any }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentByIdPublicAccess(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(PutDocumentPublicAccessTool);

--- a/src/umb-management-api/tools/document/put/sort-document.ts
+++ b/src/umb-management-api/tools/document/put/sort-document.ts
@@ -5,22 +5,27 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const SortDocumentTool = {
   name: "sort-document",
   description: "Sorts the order of documents under a parent.",
   inputSchema: putDocumentSortBody.shape,
+  outputSchema: emptyOutputShape,
   annotations: {},
   slices: ['sort'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Sort),
   handler: (async (model: z.infer<typeof putDocumentSortBody>) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentSort(model, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof putDocumentSortBody.shape>;
+} satisfies ToolDefinition<typeof putDocumentSortBody.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(SortDocumentTool);

--- a/src/umb-management-api/tools/document/put/unpublish-document.ts
+++ b/src/umb-management-api/tools/document/put/unpublish-document.ts
@@ -5,9 +5,13 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: z.string().uuid(),
@@ -18,6 +22,7 @@ const UnpublishDocumentTool = {
   name: "unpublish-document",
   description: "Unpublishes a document by Id.",
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {},
   slices: ['publish'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Unpublish),
@@ -26,10 +31,10 @@ const UnpublishDocumentTool = {
     data: z.infer<typeof putDocumentByIdUnpublishBody>;
   }) => {
     if (!model.data.cultures) model.data.cultures = null;
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentByIdUnpublish(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(UnpublishDocumentTool);

--- a/src/umb-management-api/tools/document/put/update-document.ts
+++ b/src/umb-management-api/tools/document/put/update-document.ts
@@ -8,9 +8,13 @@ import { UmbracoDocumentPermissions } from "../constants.js";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: putDocumentByIdParams.shape.id,
@@ -33,16 +37,17 @@ const UpdateDocumentTool = {
   - Only update the required values
   - Don't miss any properties from the original document`,
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['update'],
   enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Update),
   handler: (async (model: { id: string; data: any }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putDocumentById(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(UpdateDocumentTool);

--- a/src/umb-management-api/tools/language/__tests__/__snapshots__/delete-language.test.ts.snap
+++ b/src/umb-management-api/tools/language/__tests__/__snapshots__/delete-language.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`delete-language should delete a language 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`delete-language should handle non-existent language 1`] = `
 {
   "content": [],

--- a/src/umb-management-api/tools/language/__tests__/__snapshots__/delete-language.test.ts.snap
+++ b/src/umb-management-api/tools/language/__tests__/__snapshots__/delete-language.test.ts.snap
@@ -12,3 +12,15 @@ exports[`delete-language should handle non-existent language 1`] = `
   },
 }
 `;
+
+exports[`delete-language should delete a language 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/language/__tests__/__snapshots__/update-language.test.ts.snap
+++ b/src/umb-management-api/tools/language/__tests__/__snapshots__/update-language.test.ts.snap
@@ -13,13 +13,3 @@ exports[`update-language should handle non-existent language 1`] = `
 }
 `;
 
-exports[`update-language should update an existing language 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/language/__tests__/__snapshots__/update-language.test.ts.snap
+++ b/src/umb-management-api/tools/language/__tests__/__snapshots__/update-language.test.ts.snap
@@ -13,3 +13,15 @@ exports[`update-language should handle non-existent language 1`] = `
 }
 `;
 
+
+exports[`update-language should update an existing language 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/language/delete/delete-language.ts
+++ b/src/umb-management-api/tools/language/delete/delete-language.ts
@@ -2,23 +2,28 @@ import { deleteLanguageByIsoCodeParams } from "@/umb-management-api/umbracoManag
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const DeleteLanguageTool = {
   name: "delete-language",
   description: "Deletes a language by ISO code",
   inputSchema: deleteLanguageByIsoCodeParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     destructiveHint: true,
   },
   slices: ['delete'],
   handler: (async ({ isoCode }: { isoCode: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.deleteLanguageByIsoCode(isoCode, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof deleteLanguageByIsoCodeParams.shape>;
+} satisfies ToolDefinition<typeof deleteLanguageByIsoCodeParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(DeleteLanguageTool);

--- a/src/umb-management-api/tools/language/put/update-language.ts
+++ b/src/umb-management-api/tools/language/put/update-language.ts
@@ -6,9 +6,13 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   isoCode: putLanguageByIsoCodeParams.shape.isoCode,
@@ -24,6 +28,7 @@ const UpdateLanguageTool = {
   name: "update-language",
   description: "Updates an existing language by ISO code",
   inputSchema: inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
@@ -32,10 +37,10 @@ const UpdateLanguageTool = {
     const params = putLanguageByIsoCodeParams.parse({ isoCode: model.isoCode });
     const body = putLanguageByIsoCodeBody.parse(model.data);
 
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putLanguageByIsoCode(params.isoCode, body, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(UpdateLanguageTool);

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/move-media.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/move-media.test.ts.snap
@@ -26,3 +26,15 @@ exports[`move-media should handle moving to non-existent target 1`] = `
 }
 `;
 
+
+exports[`move-media should move a media item to another folder 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/move-media.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/move-media.test.ts.snap
@@ -26,13 +26,3 @@ exports[`move-media should handle moving to non-existent target 1`] = `
 }
 `;
 
-exports[`move-media should move a media item to another folder 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
@@ -13,13 +13,3 @@ exports[`move-media-to-recycle-bin should handle non-existent media 1`] = `
 }
 `;
 
-exports[`move-media-to-recycle-bin should move a media item to recycle bin 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/move-to-recycle-bin.test.ts.snap
@@ -13,3 +13,15 @@ exports[`move-media-to-recycle-bin should handle non-existent media 1`] = `
 }
 `;
 
+
+exports[`move-media-to-recycle-bin should move a media item to recycle bin 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/restore-from-recycle-bin.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/restore-from-recycle-bin.test.ts.snap
@@ -13,13 +13,3 @@ exports[`restore-media-from-recycle-bin should handle non-existent media 1`] = `
 }
 `;
 
-exports[`restore-media-from-recycle-bin should restore a media item from recycle bin 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/restore-from-recycle-bin.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/restore-from-recycle-bin.test.ts.snap
@@ -13,3 +13,15 @@ exports[`restore-media-from-recycle-bin should handle non-existent media 1`] = `
 }
 `;
 
+
+exports[`restore-media-from-recycle-bin should restore a media item from recycle bin 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/sort-media.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/sort-media.test.ts.snap
@@ -13,13 +13,3 @@ exports[`sort-media should handle non-existent parent 1`] = `
 }
 `;
 
-exports[`sort-media should sort media items 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/sort-media.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/sort-media.test.ts.snap
@@ -13,3 +13,15 @@ exports[`sort-media should handle non-existent parent 1`] = `
 }
 `;
 
+
+exports[`sort-media should sort media items 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/update-media.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/update-media.test.ts.snap
@@ -13,3 +13,27 @@ exports[`update-media should handle non-existent media 1`] = `
 }
 `;
 
+
+exports[`update-media should update a media item 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;
+
+exports[`update-media should update media with new content 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/media/__tests__/__snapshots__/update-media.test.ts.snap
+++ b/src/umb-management-api/tools/media/__tests__/__snapshots__/update-media.test.ts.snap
@@ -13,24 +13,3 @@ exports[`update-media should handle non-existent media 1`] = `
 }
 `;
 
-exports[`update-media should update a media item 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
-exports[`update-media should update media with new content 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;

--- a/src/umb-management-api/tools/media/put/move-media.ts
+++ b/src/umb-management-api/tools/media/put/move-media.ts
@@ -4,9 +4,13 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: putMediaByIdMoveParams.shape.id,
@@ -17,15 +21,16 @@ const MoveMediaTool = {
   name: "move-media",
   description: "Move a media item to a new location",
   inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['move'],
   handler: (async (model: { id: string; data: MoveMediaRequestModel }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putMediaByIdMove(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(MoveMediaTool);

--- a/src/umb-management-api/tools/media/put/move-to-recycle-bin.ts
+++ b/src/umb-management-api/tools/media/put/move-to-recycle-bin.ts
@@ -2,23 +2,28 @@ import { putMediaByIdMoveToRecycleBinParams } from "@/umb-management-api/umbraco
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const MoveMediaToRecycleBinTool = {
   name: "move-media-to-recycle-bin",
   description: "Move a media item to the recycle bin",
   inputSchema: putMediaByIdMoveToRecycleBinParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['move', 'recycle-bin'],
   handler: (async ({ id }: { id: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putMediaByIdMoveToRecycleBin(id, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof putMediaByIdMoveToRecycleBinParams.shape>;
+} satisfies ToolDefinition<typeof putMediaByIdMoveToRecycleBinParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(MoveMediaToRecycleBinTool);

--- a/src/umb-management-api/tools/media/put/restore-from-recycle-bin.ts
+++ b/src/umb-management-api/tools/media/put/restore-from-recycle-bin.ts
@@ -2,23 +2,28 @@ import { putRecycleBinMediaByIdRestoreParams } from "@/umb-management-api/umbrac
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const RestoreFromRecycleBinTool = {
   name: "restore-media-from-recycle-bin",
   description: "Restores a media item from the recycle bin.",
   inputSchema: putRecycleBinMediaByIdRestoreParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['move', 'recycle-bin'],
   handler: (async ({ id }: { id: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putRecycleBinMediaByIdRestore(id, { target: null }, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof putRecycleBinMediaByIdRestoreParams.shape>;
+} satisfies ToolDefinition<typeof putRecycleBinMediaByIdRestoreParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(RestoreFromRecycleBinTool);

--- a/src/umb-management-api/tools/media/put/sort-media.ts
+++ b/src/umb-management-api/tools/media/put/sort-media.ts
@@ -3,23 +3,28 @@ import { putMediaSortBody } from "@/umb-management-api/umbracoManagementAPI.zod.
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const SortMediaTool = {
   name: "sort-media",
   description: "Sorts the order of media items under a parent.",
   inputSchema: putMediaSortBody.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['sort'],
   handler: (async (model: SortingRequestModel) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putMediaSort(model, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof putMediaSortBody.shape>;
+} satisfies ToolDefinition<typeof putMediaSortBody.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(SortMediaTool);

--- a/src/umb-management-api/tools/media/put/update-media.ts
+++ b/src/umb-management-api/tools/media/put/update-media.ts
@@ -7,9 +7,13 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = {
   id: putMediaByIdParams.shape.id,
@@ -23,15 +27,16 @@ const UpdateMediaTool = {
   Don't miss any properties from the original media that you are updating.
   This cannot be used for moving media to a new folder. Use the move endpoint to do that.`,
   inputSchema,
+  outputSchema: emptyOutputShape,
   annotations: {
     idempotentHint: true,
   },
   slices: ['update'],
   handler: (async (model: { id: string; data: UpdateMediaRequestModel }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putMediaById(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema>;
+} satisfies ToolDefinition<typeof inputSchema, EmptyOutputShape>;
 
 export default withStandardDecorators(UpdateMediaTool);

--- a/src/umb-management-api/tools/member-group/__tests__/__snapshots__/delete-member-group.test.ts.snap
+++ b/src/umb-management-api/tools/member-group/__tests__/__snapshots__/delete-member-group.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`delete-member-group should delete a member group 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`delete-member-group should handle non-existent member group 1`] = `
 {
   "content": [],

--- a/src/umb-management-api/tools/member-group/__tests__/__snapshots__/delete-member-group.test.ts.snap
+++ b/src/umb-management-api/tools/member-group/__tests__/__snapshots__/delete-member-group.test.ts.snap
@@ -12,3 +12,15 @@ exports[`delete-member-group should handle non-existent member group 1`] = `
   },
 }
 `;
+
+exports[`delete-member-group should delete a member group 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/member-group/delete/delete-member-group.ts
+++ b/src/umb-management-api/tools/member-group/delete/delete-member-group.ts
@@ -2,23 +2,28 @@ import { deleteMemberGroupByIdParams } from "@/umb-management-api/umbracoManagem
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const DeleteMemberGroupTool = {
   name: "delete-member-group",
   description: "Deletes a member group by Id",
   inputSchema: deleteMemberGroupByIdParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     destructiveHint: true,
   },
   slices: ['delete'],
   handler: (async ({ id }: { id: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.deleteMemberGroupById(id, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof deleteMemberGroupByIdParams.shape>;
+} satisfies ToolDefinition<typeof deleteMemberGroupByIdParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(DeleteMemberGroupTool);

--- a/src/umb-management-api/tools/member/__tests__/__snapshots__/delete-member.test.ts.snap
+++ b/src/umb-management-api/tools/member/__tests__/__snapshots__/delete-member.test.ts.snap
@@ -12,3 +12,15 @@ exports[`delete-member should return error for non-existent ID 1`] = `
   },
 }
 `;
+
+exports[`delete-member should delete a member by ID 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/member/__tests__/__snapshots__/delete-member.test.ts.snap
+++ b/src/umb-management-api/tools/member/__tests__/__snapshots__/delete-member.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`delete-member should delete a member by ID 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`delete-member should return error for non-existent ID 1`] = `
 {
   "content": [],

--- a/src/umb-management-api/tools/member/delete/delete-member.ts
+++ b/src/umb-management-api/tools/member/delete/delete-member.ts
@@ -2,23 +2,28 @@ import { deleteMemberByIdParams } from "@/umb-management-api/umbracoManagementAP
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const DeleteMemberTool = {
   name: "delete-member",
   description: "Deletes a member by Id",
   inputSchema: deleteMemberByIdParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     destructiveHint: true,
   },
   slices: ['delete'],
   handler: (async ({ id }: { id: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.deleteMemberById(id, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof deleteMemberByIdParams.shape>;
+} satisfies ToolDefinition<typeof deleteMemberByIdParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(DeleteMemberTool);

--- a/src/umb-management-api/tools/member/put/update-member.ts
+++ b/src/umb-management-api/tools/member/put/update-member.ts
@@ -7,9 +7,13 @@ import { z } from "zod";
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const inputSchema = z.object({
   id: putMemberByIdParams.shape.id,
@@ -20,13 +24,14 @@ const UpdateMemberTool = {
   name: "update-member",
   description: "Updates a member by Id",
   inputSchema: inputSchema.shape,
+  outputSchema: emptyOutputShape,
   annotations: { idempotentHint: true },
   slices: ['update'],
   handler: (async (model: { id: string; data: UpdateMemberRequestModel }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.putMemberById(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof inputSchema.shape>;
+} satisfies ToolDefinition<typeof inputSchema.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(UpdateMemberTool);

--- a/src/umb-management-api/tools/redirect/__tests__/__snapshots__/redirect-management.test.ts.snap
+++ b/src/umb-management-api/tools/redirect/__tests__/__snapshots__/redirect-management.test.ts.snap
@@ -30,3 +30,15 @@ exports[`Redirect Management Tools GetRedirectByIdTool should get a redirect by 
   },
 }
 `;
+
+exports[`Redirect Management Tools DeleteRedirectTool should delete a redirect 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+  "structuredContent": {},
+}
+`;

--- a/src/umb-management-api/tools/redirect/__tests__/__snapshots__/redirect-management.test.ts.snap
+++ b/src/umb-management-api/tools/redirect/__tests__/__snapshots__/redirect-management.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Redirect Management Tools DeleteRedirectTool should delete a redirect 1`] = `
-{
-  "content": [
-    {
-      "text": "",
-      "type": "text",
-    },
-  ],
-}
-`;
-
 exports[`Redirect Management Tools DeleteRedirectTool should delete a redirect 2`] = `
 {
   "content": [],

--- a/src/umb-management-api/tools/redirect/delete/delete-redirect.ts
+++ b/src/umb-management-api/tools/redirect/delete/delete-redirect.ts
@@ -2,9 +2,13 @@ import { deleteRedirectManagementByIdParams } from "@/umb-management-api/umbraco
 import {
   type ToolDefinition,
   CAPTURE_RAW_HTTP_RESPONSE,
-  executeVoidApiCall,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
+import {
+  emptyOutputShape,
+  executeVoidApiCallWithEmptyOutput,
+  type EmptyOutputShape,
+} from "../../shared/execute-void-with-empty-output.js";
 
 const DeleteRedirectTool = {
   name: "delete-redirect",
@@ -12,15 +16,16 @@ const DeleteRedirectTool = {
   Parameters:
   - id: The unique identifier of the redirect to delete (string)`,
   inputSchema: deleteRedirectManagementByIdParams.shape,
+  outputSchema: emptyOutputShape,
   annotations: {
     destructiveHint: true,
   },
   slices: ['delete'],
   handler: (async ({ id }: { id: string }) => {
-    return executeVoidApiCall((client) =>
+    return executeVoidApiCallWithEmptyOutput((client) =>
       client.deleteRedirectManagementById(id, CAPTURE_RAW_HTTP_RESPONSE)
     );
   }),
-} satisfies ToolDefinition<typeof deleteRedirectManagementByIdParams.shape>;
+} satisfies ToolDefinition<typeof deleteRedirectManagementByIdParams.shape, EmptyOutputShape>;
 
 export default withStandardDecorators(DeleteRedirectTool);

--- a/src/umb-management-api/tools/shared/execute-void-with-empty-output.ts
+++ b/src/umb-management-api/tools/shared/execute-void-with-empty-output.ts
@@ -1,0 +1,24 @@
+import {
+  executeVoidApiCall,
+  type HttpResponse,
+  type ProblemDetails,
+} from "@umbraco-cms/mcp-server-sdk";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+// Shared empty output schema for void mutation tools. Pairs with executeVoidApiCallWithEmptyOutput
+// so the tool registry exposes `output: {}` instead of `unknown`, while the runtime still satisfies
+// MCP SDK output validation by emitting structuredContent: {}.
+export const emptyOutputSchema = z.object({});
+export const emptyOutputShape = emptyOutputSchema.shape;
+export type EmptyOutputShape = typeof emptyOutputShape;
+
+// Like executeVoidApiCall but ensures structuredContent: {} is set on success,
+// so tools that declare outputSchema: emptyOutputShape pass MCP SDK output validation.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function executeVoidApiCallWithEmptyOutput<TClient = any>(
+  apiCall: (client: TClient) => Promise<HttpResponse<ProblemDetails | void> | unknown>
+): Promise<CallToolResult> {
+  const result = await executeVoidApiCall(apiCall);
+  return result.isError ? result : { ...result, structuredContent: {} };
+}


### PR DESCRIPTION
## Summary

- Adds `outputSchema` to 26 mutation tools (closes #172) so the `@umbraco-cms/mcp-dev/tool-types` registry produces typed outputs instead of `output: unknown` — downstream consumers can drop the `as { ... }` assertions at every call site.
- Bumps `@umbraco-cms/mcp-server-sdk` from `^17.0.0-beta.16` to `^17.0.0-beta.18` (closes #180), which picks up [umbraco/Umbraco-MCP-Base#87](https://github.com/umbraco/Umbraco-MCP-Base/pull/87)'s tightened `rejectPathTraversal`.
- Adds `src/umb-management-api/tools/shared/execute-void-with-empty-output.ts`: `emptyOutputShape` + `executeVoidApiCallWithEmptyOutput()` wrapper that emits `structuredContent: {}` on success, required because the MCP SDK rejects results with an `outputSchema` but no `structuredContent`.

## Tool changes

- **`create-document-blueprint-from-document`** → `outputSchema: { id: z.string().guid() }`, handler extracts the id from the `Location` header (same shape as `create-webhook`).
- **25 void tools** → `outputSchema: emptyOutputShape` + `executeVoidApiCallWithEmptyOutput()`:
  `create-document-version-rollback`, `delete-document-public-access`, `delete-language`, `delete-member`, `delete-member-group`, `delete-redirect`, `move-dictionary-item`, `move-document`, `move-document-to-recycle-bin`, `move-media`, `move-media-to-recycle-bin`, `post-document-public-access`, `publish-document`, `publish-document-with-descendants`, `put-document-notifications`, `put-document-public-access`, `restore-media-from-recycle-bin`, `sort-document`, `sort-media`, `unpublish-document`, `update-dictionary-item`, `update-document`, `update-language`, `update-media`, `update-member`.

## Notes / behaviour deltas

- The issue table listed `create-document-version-rollback` as `{ id }`, but the Orval-generated API is `<void>` (rollback isn't a creation), so I treated it as void.
- `publish-document-with-descendants` does its own async polling, not `executeVoidApiCall`. Success paths now emit `structuredContent: {}`; the polling-error and timeout paths are flagged with `isError: true` so output validation is skipped (and these genuinely are errors — the original code returned them as plain content, which was a latent issue).
- **Out of scope**: `restore-document-from-recycle-bin` has the same `output: unknown` shape but wasn't listed in #172.
- **No code change for #180** — the SDK bump alone fixes the Windows `filePath` rejection. The `[raw]` workaround on `feature/fix-180-windows-filepath` was never merged into `dev`, so nothing to revert here. #181 already closed as moot.

## Test plan

- [x] `npm run compile` passes on `feature/output-schema-mutations`.
- [ ] Re-run integration tests for the affected tools and update snapshots — every success-case snapshot for the 25 void tools currently looks like `{ content: [{ text: "", type: "text" }] }` and now becomes `{ content: [...], structuredContent: {} }`. The blueprint creator's success snapshot now contains `{ id: "..." }`. Run `jest -u` against the affected test files.
- [ ] Verify Windows `filePath` upload via `create-media` against `UMBRACO_ALLOWED_MEDIA_PATHS` (covered by SDK PR #87 tests; no extra coverage needed here).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)