### PR TITLE
Release/17.3.6 — bump mcp-hosted/SDK to 17.0.0-beta.20

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.3.5",
+    "version": "17.3.6",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.3.5",
+      "version": "17.3.6",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.3.5",
+  "version": "17.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.3.5",
+      "version": "17.3.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@types/uuid": "^10.0.0",
         "@types/yargs": "^17.0.33",
-        "@umbraco-cms/mcp-hosted": "^17.0.0-beta.19",
-        "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.19",
+        "@umbraco-cms/mcp-hosted": "^17.0.0-beta.20",
+        "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.20",
         "axios": "^1.8.4",
         "dotenv": "^16.5.0",
         "form-data": "^4.0.4",
@@ -3774,14 +3774,14 @@
       "license": "MIT"
     },
     "node_modules/@umbraco-cms/mcp-hosted": {
-      "version": "17.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-hosted/-/mcp-hosted-17.0.0-beta.19.tgz",
-      "integrity": "sha512-NpyNa4XK4GrVDaABHPmH7XjSM1pitd6TVH97echGpKmrpR11w9lNQ+AegQYRTGCiDM/tZm2HwEjXwpsu1xkEmQ==",
+      "version": "17.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-hosted/-/mcp-hosted-17.0.0-beta.20.tgz",
+      "integrity": "sha512-nAaIYLuIeTPnAmZMZ5mElUz/AQ7jQySC41owEj7TIJ0plojimz3QV2k6uOfGYx0MKsl/OiE9HMujTjeG6ffYKQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@umbraco-cms/mcp-server-sdk": "17.0.0-beta.19",
+        "@umbraco-cms/mcp-server-sdk": "17.0.0-beta.20",
         "zod": "^4.2.1"
       },
       "engines": {
@@ -3797,9 +3797,9 @@
       }
     },
     "node_modules/@umbraco-cms/mcp-server-sdk": {
-      "version": "17.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-server-sdk/-/mcp-server-sdk-17.0.0-beta.19.tgz",
-      "integrity": "sha512-/Lo4Tpw6MCFmJp0ysjqVnbtmZ1zh3B7bIQUp1VU5G6khut05QJl6Hw6U3iSK8b/q/65RqiNlKDiUPCQ+ZGnzjg==",
+      "version": "17.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-server-sdk/-/mcp-server-sdk-17.0.0-beta.20.tgz",
+      "integrity": "sha512-y2e6J7n540kc9Qm+x3aGB34NyFR4bLD+ihZrXoedacl+WeYR+4ELWzC10fsH7GpYEZPUjuFPA/CcDHnd2FlBAQ==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.3.5",
+  "version": "17.3.6",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",
@@ -68,8 +68,8 @@
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@types/uuid": "^10.0.0",
     "@types/yargs": "^17.0.33",
-    "@umbraco-cms/mcp-hosted": "^17.0.0-beta.19",
-    "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.19",
+    "@umbraco-cms/mcp-hosted": "^17.0.0-beta.20",
+    "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.20",
     "axios": "^1.8.4",
     "dotenv": "^16.5.0",
     "form-data": "^4.0.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.3.5",
+  "version": "17.3.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.3.5",
+      "version": "17.3.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumped \`@umbraco-cms/mcp-hosted\` and \`@umbraco-cms/mcp-server-sdk\` to \`17.0.0-beta.20\`.

Lib-internal changes picked up automatically when \`UMBRACO_CLOUD_ROUTING_ENABLED=true\`:
- Tenant-pinned \`authorization_servers\` so non-RFC-8707 clients (notably ChatGPT) can complete OAuth against site-routed Workers without sending \`resource\`. New RFC 8414 §3 AS metadata at \`/.well-known/oauth-authorization-server/at/<alias>\`.
- Per-tenant Dynamic Client Registration via \`/at/<alias>/register\`; root \`/register\` returns 404 under siteRouting.
- Confused-deputy defence at root \`/authorize\` (reverse-index lookup + strict \`resource\` validation).
- Audience synthesis when client omits \`resource\` at a tenant-prefixed authorize.

Rollout: canonical \`aud\` becomes \`\${origin}/at/<alias>\`. In-flight tokens fail audience validation until they expire (60-minute default TTL). No transitional dual-\`aud\` acceptance.