### PR TITLE
Merge main into dev (post 17.3.7 release)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.3.6",
+    "version": "17.3.7",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.3.6",
+      "version": "17.3.7",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.3.6",
+  "version": "17.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.3.6",
+      "version": "17.3.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@types/uuid": "^10.0.0",
         "@types/yargs": "^17.0.33",
-        "@umbraco-cms/mcp-hosted": "^17.0.0-beta.20",
-        "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.20",
+        "@umbraco-cms/mcp-hosted": "^17.0.0-beta.21",
+        "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.21",
         "axios": "^1.8.4",
         "dotenv": "^16.5.0",
         "form-data": "^4.0.4",
@@ -3774,14 +3774,14 @@
       "license": "MIT"
     },
     "node_modules/@umbraco-cms/mcp-hosted": {
-      "version": "17.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-hosted/-/mcp-hosted-17.0.0-beta.20.tgz",
-      "integrity": "sha512-nAaIYLuIeTPnAmZMZ5mElUz/AQ7jQySC41owEj7TIJ0plojimz3QV2k6uOfGYx0MKsl/OiE9HMujTjeG6ffYKQ==",
+      "version": "17.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-hosted/-/mcp-hosted-17.0.0-beta.21.tgz",
+      "integrity": "sha512-tZIEMhQd7nxrWXAJNyprnK9tnR7DnVIMv/QXIeJK9JbikB/ERhu1CjAJDk/ugoRFaPJCT4VultcWc1kwRdW/fA==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@umbraco-cms/mcp-server-sdk": "17.0.0-beta.20",
+        "@umbraco-cms/mcp-server-sdk": "17.0.0-beta.21",
         "zod": "^4.2.1"
       },
       "engines": {
@@ -3797,9 +3797,9 @@
       }
     },
     "node_modules/@umbraco-cms/mcp-server-sdk": {
-      "version": "17.0.0-beta.20",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-server-sdk/-/mcp-server-sdk-17.0.0-beta.20.tgz",
-      "integrity": "sha512-y2e6J7n540kc9Qm+x3aGB34NyFR4bLD+ihZrXoedacl+WeYR+4ELWzC10fsH7GpYEZPUjuFPA/CcDHnd2FlBAQ==",
+      "version": "17.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/mcp-server-sdk/-/mcp-server-sdk-17.0.0-beta.21.tgz",
+      "integrity": "sha512-fz05y+LDsawO1ouVxvGL1iRo8Hww0Oh/zk3zJuuih0yzk7jsXic/uuFBo1uhBf3CTa2/rgSCcMiQtqb6gk/D+g==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.3.6",
+  "version": "17.3.7",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",
@@ -68,8 +68,8 @@
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@types/uuid": "^10.0.0",
     "@types/yargs": "^17.0.33",
-    "@umbraco-cms/mcp-hosted": "^17.0.0-beta.20",
-    "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.20",
+    "@umbraco-cms/mcp-hosted": "^17.0.0-beta.21",
+    "@umbraco-cms/mcp-server-sdk": "^17.0.0-beta.21",
     "axios": "^1.8.4",
     "dotenv": "^16.5.0",
     "form-data": "^4.0.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.3.6",
+  "version": "17.3.7",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.3.6",
+      "version": "17.3.7",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Brings `main` back into `dev` after the 17.3.7 release (PR #195).
- Net file diff: the SDK bump (`@umbraco-cms/mcp-hosted` and `@umbraco-cms/mcp-server-sdk` → `17.0.0-beta.21`) and version bumps `17.3.6` → `17.3.7` across `package.json`, `package-lock.json`, `.claude-plugin/marketplace.json`, `server.json`.

## Test plan
- [ ] CI green