### PR TITLE
chore: target dev for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: dev
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: dev


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so Dependabot opens new npm and github-actions update PRs against `dev` rather than the default branch (`main`).
- Fits the release flow: deps churn on dev → bundled into a release branch cut from dev → squash-merged to main → main back-merged into dev.

## Notes
- Only affects **new** Dependabot PRs. The currently-open Dependabot branches (`fast-uri-3.1.2`, `hono-4.12.18`, `uuid-14.0.0`) still target main. After this lands, either close them and let Dependabot reopen against dev, or comment `@dependabot recreate` on each.

## Test plan
- [ ] CI green
- [ ] After merge, observe Dependabot opens its next round of PRs with `base: dev`