### PR TITLE
fix(create-document): auto-apply default template (#58)

### DIFF
--- a/src/umb-management-api/tools/document/__tests__/__snapshots__/create-document.test.ts.snap
+++ b/src/umb-management-api/tools/document/__tests__/__snapshots__/create-document.test.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`create-document should apply an explicit templateId when provided 1`] = `
+{
+  "content": [],
+  "structuredContent": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "message": "Document created successfully",
+  },
+}
+`;
+
+exports[`create-document should auto-apply the document type's default template when templateId is omitted 1`] = `
+{
+  "content": [],
+  "structuredContent": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "message": "Document created successfully",
+  },
+}
+`;
+
 exports[`create-document should create a document 1`] = `
 {
   "content": [],
@@ -87,6 +107,16 @@ exports[`create-document should create a document with empty cultures array (nul
 `;
 
 exports[`create-document should create a document with specific cultures 1`] = `
+{
+  "content": [],
+  "structuredContent": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "message": "Document created successfully",
+  },
+}
+`;
+
+exports[`create-document should create the document with no template when the doc type has no default 1`] = `
 {
   "content": [],
   "structuredContent": {

--- a/src/umb-management-api/tools/document/__tests__/create-document.test.ts
+++ b/src/umb-management-api/tools/document/__tests__/create-document.test.ts
@@ -9,14 +9,22 @@ import {
   setupTestEnvironment,
   validateToolResponse,
 } from "@umbraco-cms/mcp-server-sdk/testing";
+import { TemplateBuilder } from "../../template/__tests__/helpers/template-builder.js";
+import { TemplateTestHelper } from "../../template/__tests__/helpers/template-helper.js";
+import { DocumentTypeBuilder } from "../../document-type/__tests__/helpers/document-type-builder.js";
+import { DocumentTypeTestHelper } from "../../document-type/__tests__/helpers/document-type-test-helper.js";
 
 const TEST_DOCUMENT_NAME = "_Test Document Created";
+const TEST_TEMPLATE_NAME = "_Test Default Template";
+const TEST_DOC_TYPE_NAME = "_Test Doc Type With Templates";
 
 describe("create-document", () => {
   setupTestEnvironment();
 
   afterEach(async () => {
     await DocumentTestHelper.cleanup(TEST_DOCUMENT_NAME);
+    await DocumentTypeTestHelper.cleanup(TEST_DOC_TYPE_NAME);
+    await TemplateTestHelper.cleanup(TEST_TEMPLATE_NAME);
   });
 
   it("should create a document", async () => {
@@ -25,6 +33,7 @@ describe("create-document", () => {
       documentTypeId: ROOT_DOCUMENT_TYPE_ID,
       name: TEST_DOCUMENT_NAME,
       parentId: undefined,
+      templateId: undefined,
       cultures: undefined,
       values: [],
     };
@@ -55,6 +64,7 @@ describe("create-document", () => {
       documentTypeId: ROOT_DOCUMENT_TYPE_ID,
       name: TEST_DOCUMENT_NAME,
       parentId: undefined,
+      templateId: undefined,
       cultures: undefined,
       values: [
         {
@@ -126,6 +136,7 @@ describe("create-document", () => {
         documentTypeId: ROOT_DOCUMENT_TYPE_ID,
         name: TEST_DOCUMENT_NAME,
         parentId: undefined,
+        templateId: undefined,
         cultures: ["en-US", "da-DK"],
         values: [],
       };
@@ -180,6 +191,7 @@ describe("create-document", () => {
       documentTypeId: ROOT_DOCUMENT_TYPE_ID,
       name: TEST_DOCUMENT_NAME,
       parentId: undefined,
+      templateId: undefined,
       cultures: [],
       values: [],
     };
@@ -198,5 +210,112 @@ describe("create-document", () => {
     // Should have single variant with null culture (original behavior)
     expect(item!.variants).toHaveLength(1);
     expect(item!.variants[0].culture).toBeNull();
+  });
+
+  it("should apply an explicit templateId when provided", async () => {
+    // Arrange: create a template and a doc type that allows it (no default).
+    const template = await new TemplateBuilder()
+      .withName(TEST_TEMPLATE_NAME)
+      .create();
+    const templateId = template.getId();
+
+    const docType = await new DocumentTypeBuilder()
+      .withName(TEST_DOC_TYPE_NAME)
+      .allowAsRoot(true)
+      .withAllowedTemplate(templateId)
+      .create();
+    const docTypeId = docType.getId();
+
+    // Act: create a document with an explicit templateId.
+    const result = await CreateDocumentTool.handler(
+      {
+        documentTypeId: docTypeId,
+        name: TEST_DOCUMENT_NAME,
+        parentId: undefined,
+        templateId,
+        cultures: undefined,
+        values: [],
+      },
+      createMockRequestHandlerExtra()
+    );
+
+    // Assert: handler succeeds, document carries the requested template.
+    const responseData = validateToolResponse(CreateDocumentTool, result);
+    expect(createSnapshotResult(result, responseData.id)).toMatchSnapshot();
+
+    // Verify the created document has the correct template assigned
+    const client = UmbracoManagementClient.getClient();
+    const document = await client.getDocumentById(responseData.id);
+    expect(document).toBeDefined();
+    expect(document.template?.id).toBe(templateId);
+  });
+
+  it("should auto-apply the document type's default template when templateId is omitted", async () => {
+    // Arrange: create a template and a doc type that uses it as default.
+    const template = await new TemplateBuilder()
+      .withName(TEST_TEMPLATE_NAME)
+      .create();
+    const templateId = template.getId();
+
+    const docType = await new DocumentTypeBuilder()
+      .withName(TEST_DOC_TYPE_NAME)
+      .allowAsRoot(true)
+      .withAllowedTemplate(templateId)
+      .withDefaultTemplate(templateId)
+      .create();
+    const docTypeId = docType.getId();
+
+    // Act: create a document WITHOUT specifying templateId.
+    const result = await CreateDocumentTool.handler(
+      {
+        documentTypeId: docTypeId,
+        name: TEST_DOCUMENT_NAME,
+        parentId: undefined,
+        templateId: undefined,
+        cultures: undefined,
+        values: [],
+      },
+      createMockRequestHandlerExtra()
+    );
+
+    // Assert: the default template was attached.
+    const responseData = validateToolResponse(CreateDocumentTool, result);
+    expect(createSnapshotResult(result, responseData.id)).toMatchSnapshot();
+
+    const client = UmbracoManagementClient.getClient();
+    const document = await client.getDocumentById(responseData.id);
+    expect(document).toBeDefined();
+    expect(document.template?.id).toBe(templateId);
+  });
+
+  it("should create the document with no template when the doc type has no default", async () => {
+    // Arrange: a doc type with no templates configured at all.
+    const docType = await new DocumentTypeBuilder()
+      .withName(TEST_DOC_TYPE_NAME)
+      .allowAsRoot(true)
+      .create();
+    const docTypeId = docType.getId();
+
+    // Act: create the document without specifying a templateId.
+    const result = await CreateDocumentTool.handler(
+      {
+        documentTypeId: docTypeId,
+        name: TEST_DOCUMENT_NAME,
+        parentId: undefined,
+        templateId: undefined,
+        cultures: undefined,
+        values: [],
+      },
+      createMockRequestHandlerExtra()
+    );
+
+    // Assert: creation still succeeds; template is null on the document.
+    const responseData = validateToolResponse(CreateDocumentTool, result);
+    expect(createSnapshotResult(result, responseData.id)).toMatchSnapshot();
+
+    const client = UmbracoManagementClient.getClient();
+    const document = await client.getDocumentById(responseData.id);
+    expect(document).toBeDefined();
+    expect(document.template).toBeNull();
   });
 });

--- a/src/umb-management-api/tools/document/__tests__/update-document-properties.test.ts
+++ b/src/umb-management-api/tools/document/__tests__/update-document-properties.test.ts
@@ -299,6 +299,7 @@ describe("update-document-properties", () => {
             { editorAlias: "Umbraco.TextBox", alias: "title", value: DA_DK_TITLE, culture: "da-DK", segment: null },
           ],
           parentId: undefined,
+          templateId: undefined,
         },
         createMockRequestHandlerExtra()
       );
@@ -359,6 +360,7 @@ describe("update-document-properties", () => {
             { editorAlias: "Umbraco.TextBox", alias: "title", value: DA_DK_TITLE, culture: "da-DK", segment: null },
           ],
           parentId: undefined,
+          templateId: undefined,
         },
         createMockRequestHandlerExtra()
       );
@@ -424,6 +426,7 @@ describe("update-document-properties", () => {
             { editorAlias: "Umbraco.TextBox", alias: "title", value: EN_US_TITLE, culture: "en-US", segment: null },
           ],
           parentId: undefined,
+          templateId: undefined,
         },
         createMockRequestHandlerExtra()
       );

--- a/src/umb-management-api/tools/document/post/create-document.ts
+++ b/src/umb-management-api/tools/document/post/create-document.ts
@@ -21,6 +21,13 @@ const createDocumentSchema = z.object({
   documentTypeId: z.string().uuid("Must be a valid document type type UUID"),
   parentId: z.string().uuid("Must be a valid document UUID").optional(),
   name: z.string(),
+  templateId: z
+    .string()
+    .uuid("Must be a valid template UUID")
+    .optional()
+    .describe(
+      "Optional template ID to apply to the document. If omitted, the document type's default template is applied automatically. Provide a value only when you need a specific allowed template other than the default."
+    ),
   cultures: z.array(z.string()).optional().describe("Array of culture codes. If not provided or empty array, will create single variant with null culture."),
   values: z
     .array(
@@ -105,6 +112,10 @@ const CreateDocumentTool = {
     "alias": "propertyAlias",          // Property alias from document type
     "value": "your value here"         // Value matching the schema structure
   }
+
+  ## Default Template
+
+  The document type's default template is applied automatically. Pass an explicit \`templateId\` only when you need a specific allowed template other than the default. If the document type has no default template, the document is created without one.
   `,
   inputSchema: createDocumentSchema.shape,
   outputSchema: createOutputSchema.shape,
@@ -133,6 +144,18 @@ const CreateDocumentTool = {
       segment: null,
     }));
 
+    // Resolve the template: explicit override wins; otherwise use the
+    // document type's default template (which may itself be null).
+    let template: { id: string } | null;
+    if (model.templateId) {
+      template = { id: model.templateId };
+    } else {
+      const docType = await client.getDocumentTypeById(model.documentTypeId);
+      template = docType.defaultTemplate?.id
+        ? { id: docType.defaultTemplate.id }
+        : null;
+    }
+
     const payload: CreateDocumentRequestModel = {
       id: documentId,
       documentType: {
@@ -143,7 +166,7 @@ const CreateDocumentTool = {
           id: model.parentId,
         }
         : undefined,
-      template: null,
+      template,
       values: model.values,
       variants,
     };


### PR DESCRIPTION
## Summary
- `create-document` was hardcoding `template: null` in the payload, so newly created documents never received the document type's default template.
- The handler now resolves the template at request time: an explicit `templateId` wins; otherwise the document type is fetched and its `defaultTemplate.id` is used (falling back to `null` when none is set).
- A new optional `templateId` input lets callers pin a specific allowed template; omitting it gives the LLM the same behaviour a backoffice user gets.

## Test plan
- [ ] `npm run compile` (already passing locally)
- [ ] `npm run umbraco:start`
- [ ] `npm test -- --no-coverage src/umb-management-api/tools/document/__tests__/create-document.test.ts`
- [ ] Confirm three new tests pass and snapshots look right
- [ ] `npm run umbraco:stop`

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)