### PR TITLE
feat(media): add create-media-from-file (openai/fileParams PoC)

### DIFF
--- a/docs/openai-file-params.md
+++ b/docs/openai-file-params.md
@@ -1,0 +1,51 @@
+# Accepting ChatGPT-attached files: `openai/fileParams`
+
+When a ChatGPT user attaches a file or asks the model to upload a file it
+generated (e.g. `/mnt/data/foo.png`), ChatGPT's connector layer **will not**
+forward that path as a plain string. It expects the MCP server to declare
+which tool parameters are file inputs. Without that declaration, the call is
+aborted before reaching the worker with:
+
+```
+ValueError: File arg rewrite paths are required when proxied mounts are present.
+```
+
+With the declaration, ChatGPT uploads the file to its own hosted store and
+passes the tool an object:
+
+```
+{ download_url, file_id, mime_type?, file_name? }
+```
+
+The `download_url` is a temporary, publicly-fetchable URL valid for the
+duration of the tool call.
+
+## How to add a file-input tool
+
+1. Make the file parameter a top-level object on the input schema with the
+   four fields above.
+2. Declare the parameter in `_meta`:
+
+   ```ts
+   _meta: { "openai/fileParams": ["file"] }
+   ```
+
+3. In the handler, `fetch(file.download_url)` to get a `Buffer`/`Blob` and
+   feed it into whatever upload path you already have.
+
+`create-media-from-file` (`src/umb-management-api/tools/media/post/
+create-media-from-file.ts`) is the reference example. It fetches the bytes
+and reuses the existing `uploadMediaFile` helper via `sourceType: "url"`.
+
+## Why it's registered directly on `McpServer`
+
+The hosted SDK's collection-registration loop in
+`@umbraco-cms/mcp-hosted` does **not** currently forward `_meta` from
+`ToolDefinition` to `McpServer.registerTool` — so a tool defined the usual
+way through a collection will be exposed without its `openai/fileParams`
+metadata, and the connector will keep refusing sandbox files.
+
+The workaround is to register the tool directly on the per-request
+`McpServer` instance in `src/worker.ts`, after `createPerRequestServer`
+returns. Once the SDK is updated to forward `_meta`, this can collapse back
+into the regular media collection.

--- a/docs/upload-from-google-drive.md
+++ b/docs/upload-from-google-drive.md
@@ -66,3 +66,24 @@ either the URL path or the `Content-Type` header.
   use the `create-media-from-file` flow (`docs/openai-file-params.md`)
   instead, which lets the host (ChatGPT) attach the file via its own
   hosted store.
+
+## Why we can't proxy Drive through `create-media-from-file`
+
+It looks tempting to route the bytes "ChatGPT pulls from Drive → Umbraco
+MCP pushes to Umbraco" so the worker fetches a fast OpenAI-hosted URL
+instead of Drive directly. In practice this doesn't work:
+
+- ChatGPT's code-interpreter sandbox has no DNS for `drive.google.com`
+  (`urlopen error [Errno -3] Temporary failure in name resolution`).
+- The built-in web fetch tool refuses Drive download endpoints too
+  (`Failed to fetch …drive.google.com/uc?export=download&id=…`).
+- ChatGPT's Google Drive connector and a third-party MCP connector
+  (Umbraco MCP) cannot both be active in the same developer-mode chat,
+  so even when both are configured, only one is exposed to the model at
+  a time. There is no bridge step inside ChatGPT that can hand a Drive
+  file off to a separate MCP connector.
+
+So the only path that actually goes "Drive → Umbraco" in one prompt is
+the `create-media` URL fetch above. `create-media-from-file` remains the
+right tool for files the user has **directly attached to the chat** (or
+that ChatGPT generated), but it can't be used to launder a Drive link.

--- a/docs/upload-from-google-drive.md
+++ b/docs/upload-from-google-drive.md
@@ -52,10 +52,11 @@ either the URL path or the `Content-Type` header.
   a `Buffer` and then POSTs them as multipart form-data to Umbraco's
   Temporary File endpoint. Both legs count toward the Cloudflare Worker
   invocation/wall-clock budget, and an MCP client (e.g. ChatGPT) has its
-  own ~30s timeout on the tool response. On `cms-dev-staging`, files
-  around **3 MB+** can hit this ceiling and surface as `TimeoutError:`
-  on the client side even though the URL fetch itself completed. Small
-  files (verified up to ~2 MB end-to-end) round-trip reliably.
+  own ~30s timeout on the tool response. Observed on `cms-dev-staging`:
+  a 188 KB Drive JPEG and a 2.2 MB generated PNG round-tripped cleanly,
+  whereas a 3.57 MB Drive JPEG consistently surfaced as `TimeoutError:`
+  on the client even though the URL fetch itself completed in the worker
+  logs. Tracked in issue #225.
 - **Drive virus-scan interstitial.** Files large enough to skip Google's
   inline scan return an HTML confirmation page instead of bytes on the
   first request. None of the small/medium images this workflow targets

--- a/docs/upload-from-google-drive.md
+++ b/docs/upload-from-google-drive.md
@@ -1,0 +1,68 @@
+# Uploading files to Umbraco from Google Drive
+
+The existing `create-media` tool accepts `sourceType: "url"` with any
+publicly-fetchable URL. Google Drive shareable links work as long as you
+convert them to the direct-download form first — the `…/file/d/<id>/view`
+URL the share dialog gives you is an HTML viewer, not the bytes.
+
+## URL transformation
+
+Given a share URL like
+
+```
+https://drive.google.com/file/d/1APmI9THGFpdz6-Tlf_IlMhfw9ojCNBYS/view?usp=sharing
+```
+
+extract the file id between `/file/d/` and `/view`, then construct either:
+
+```
+https://drive.google.com/uc?export=download&id=<FILE_ID>
+```
+
+(which 302-redirects to `drive.usercontent.google.com`) or use the
+redirect target directly:
+
+```
+https://drive.usercontent.google.com/download?id=<FILE_ID>&export=download
+```
+
+Both return the file bytes with a proper `Content-Type`. The file must be
+shared with **Anyone with the link** — files restricted to a Google
+account can't be fetched anonymously by the worker.
+
+## Calling `create-media`
+
+```json
+{
+  "sourceType": "url",
+  "fileUrl": "https://drive.google.com/uc?export=download&id=<FILE_ID>",
+  "name": "my-asset",
+  "mediaTypeName": "Image"
+}
+```
+
+`mediaTypeName` follows the standard set (`Image`, `Article`, `Audio`,
+`Video`, `Vector Graphics (SVG)`, `File`, or a custom type). The tool
+auto-appends an extension to `name` if one isn't provided — derived from
+either the URL path or the `Content-Type` header.
+
+## Known limits
+
+- **Worker invocation budget.** The hosted worker fetches the bytes into
+  a `Buffer` and then POSTs them as multipart form-data to Umbraco's
+  Temporary File endpoint. Both legs count toward the Cloudflare Worker
+  invocation/wall-clock budget, and an MCP client (e.g. ChatGPT) has its
+  own ~30s timeout on the tool response. On `cms-dev-staging`, files
+  around **3 MB+** can hit this ceiling and surface as `TimeoutError:`
+  on the client side even though the URL fetch itself completed. Small
+  files (verified up to ~2 MB end-to-end) round-trip reliably.
+- **Drive virus-scan interstitial.** Files large enough to skip Google's
+  inline scan return an HTML confirmation page instead of bytes on the
+  first request. None of the small/medium images this workflow targets
+  hit that limit, but if you ever see a `text/html` response with a
+  `confirm=` token, the file needs the two-request `&confirm=t` dance
+  — outside the scope of `create-media`'s plain URL fetch.
+- **No private Drive auth.** OAuth-restricted files aren't supported —
+  use the `create-media-from-file` flow (`docs/openai-file-params.md`)
+  instead, which lets the host (ChatGPT) attach the file via its own
+  hosted store.

--- a/src/umb-management-api/tools/media/post/create-media-from-file.ts
+++ b/src/umb-management-api/tools/media/post/create-media-from-file.ts
@@ -1,0 +1,98 @@
+/**
+ * Create-media variant for ChatGPT proxied-file uploads.
+ *
+ * Declares `openai/fileParams: ["file"]` so ChatGPT's connector will upload
+ * the user's sandbox file to its hosted store and pass a
+ * `{ download_url, file_id, mime_type, file_name }` object instead of the
+ * raw `/mnt/data/...` path (which fails with "File arg rewrite paths are
+ * required when proxied mounts are present.").
+ *
+ * Registered directly on the McpServer in worker.ts because the SDK's
+ * tool-registration loop doesn't currently forward `_meta`.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { v4 as uuidv4 } from "uuid";
+import { UmbracoManagementClient } from "../../../umbraco-management-client.js";
+import { uploadMediaFile } from "./helpers/media-upload-helpers.js";
+import {
+  MEDIA_TYPE_ARTICLE,
+  MEDIA_TYPE_AUDIO,
+  MEDIA_TYPE_FILE,
+  MEDIA_TYPE_IMAGE,
+  MEDIA_TYPE_VECTOR_GRAPHICS,
+  MEDIA_TYPE_VIDEO,
+} from "@umbraco-cms/mcp-server-sdk";
+
+const fileShape = {
+  download_url: z.string().describe("Temporary URL provided by the host to fetch the file bytes"),
+  file_id: z.string().describe("Persistent file identifier from the host"),
+  mime_type: z.string().optional().describe("MIME type of the file, if known"),
+  file_name: z.string().optional().describe("Original file name, if known"),
+};
+
+const inputShape = {
+  file: z.object(fileShape).describe("File reference provided by the ChatGPT host (uploaded or generated)"),
+  name: z.string().describe("The name of the media item"),
+  mediaTypeName: z.string().describe(
+    `Media type: '${MEDIA_TYPE_IMAGE}', '${MEDIA_TYPE_ARTICLE}', '${MEDIA_TYPE_AUDIO}', '${MEDIA_TYPE_VIDEO}', '${MEDIA_TYPE_VECTOR_GRAPHICS}', '${MEDIA_TYPE_FILE}', or a custom media type name`
+  ),
+  parentId: z.string().uuid().optional().describe("Parent folder ID (defaults to root)"),
+};
+
+const outputShape = {
+  message: z.string(),
+  name: z.string(),
+  id: z.string().uuid(),
+};
+
+export function registerCreateMediaFromFileTool(server: McpServer): void {
+  server.registerTool(
+    "create-media-from-file",
+    {
+      description:
+        "Upload a media file to Umbraco using a file reference provided by the ChatGPT host (proxied mount, generated image, or user upload). " +
+        "Prefer this tool over `create-media` whenever the source is a file the user attached or that ChatGPT generated in its sandbox — " +
+        "ChatGPT will host the file and pass a `{ download_url, file_id }` object on the `file` parameter.",
+      inputSchema: inputShape,
+      outputSchema: outputShape,
+      annotations: { title: "Create media from file (ChatGPT-hosted)" },
+      _meta: { "openai/fileParams": ["file"] },
+    },
+    async (model) => {
+      try {
+        const client = UmbracoManagementClient.getClient();
+        const temporaryFileId = uuidv4();
+
+        const { name: actualName, id } = await uploadMediaFile(client, {
+          sourceType: "url",
+          name: model.name,
+          mediaTypeName: model.mediaTypeName,
+          fileUrl: model.file.download_url,
+          parentId: model.parentId,
+          temporaryFileId,
+        });
+
+        const structured = {
+          message: `Media "${actualName}" created successfully`,
+          name: actualName,
+          id,
+        };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(structured) }],
+          structuredContent: structured,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error creating media: ${(error as Error).message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/umb-management-api/tools/media/post/create-media.ts
+++ b/src/umb-management-api/tools/media/post/create-media.ts
@@ -36,7 +36,7 @@ export function createCreateMediaTool(options: { allowFilePath: boolean }) {
     name: z.string().describe("The name of the media item"),
     mediaTypeName: z.string().describe(`Media type: '${MEDIA_TYPE_IMAGE}', '${MEDIA_TYPE_ARTICLE}', '${MEDIA_TYPE_AUDIO}', '${MEDIA_TYPE_VIDEO}', '${MEDIA_TYPE_VECTOR_GRAPHICS}', '${MEDIA_TYPE_FILE}', or custom media type name`),
     filePath: z.string().optional().describe("Absolute path to the file (required if sourceType is 'filePath')"),
-    fileUrl: z.string().url().optional().describe("[raw] URL to fetch the file from (required if sourceType is 'url')"),
+    fileUrl: z.string().url().optional().describe("[raw] Public, direct-download URL to fetch the file from (required if sourceType is 'url'). Must be reachable without authentication. Share/viewer links (e.g. drive.google.com/file/d/<id>/view, Dropbox ?dl=0, OneDrive view URLs) must be converted to their direct-download equivalent first — Google Drive: drive.google.com/uc?export=download&id=<id>. Check the file's content-length before calling: uploads above ~3 MB currently time out on the hosted Worker (see issue #225)."),
     fileAsBase64: z.string().optional().describe("Base64 encoded file data (required if sourceType is 'base64')"),
     parentId: z.string().uuid().optional().describe("Parent folder ID (defaults to root)"),
   });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -25,6 +25,7 @@ import { umbracoCloudSiteRouting } from "@umbraco-cms/mcp-hosted/cloud";
 // CMS collections and registries
 import { collections, allModes, allModeNames, allSliceNames } from "./collections.js";
 import { UmbracoManagementClient } from "./umb-management-api/umbraco-management-client.js";
+import { registerCreateMediaFromFileTool } from "./umb-management-api/tools/media/post/create-media-from-file.js";
 
 // ============================================================================
 // Server Configuration
@@ -58,6 +59,7 @@ export class UmbracoMcpAgent extends McpAgent<HostedMcpEnv, unknown, AuthProps> 
       this.env,
       this.props!,
     );
+    registerCreateMediaFromFileTool(this.server);
   }
 
   // Diagnostic: surface stack traces for the otherwise-opaque


### PR DESCRIPTION
## Summary
- Adds `create-media-from-file` MCP tool that declares `_meta: { "openai/fileParams": ["file"] }`, allowing ChatGPT's connector to upload sandboxed / user-attached files (e.g. `/mnt/data/foo.png`, generated images) to its hosted store and pass `{ download_url, file_id, mime_type, file_name }` to the Worker — bypassing the **"File arg rewrite paths are required when proxied mounts are present"** error that blocks `create-media` for proxied mounts.
- Registered directly on the `McpServer` in `worker.ts` because `@umbraco-cms/mcp-hosted`'s collection-registration loop does not currently forward `_meta` from `ToolDefinition`. Follow-up work: thread `_meta` through the SDK so the new tool can live in the regular `media` collection alongside `create-media`.
- PoC scope — verified end-to-end against `umbraco-cms-dev-mcp-staging`:
  - ChatGPT generated a foal image → called `create-media-from-file` → Worker fetched the 2.2 MB asset from the OpenAI-hosted `download_url` → Umbraco returned media id `25b2ba59-aa26-4cbf-8d36-2d35c8f97e7a`.

## Test plan
- [ ] Connect a ChatGPT developer-mode connector to the deployed Worker and confirm `create-media-from-file` appears in the actions list.
- [ ] Generate an image (or attach a file) in ChatGPT and ask it to upload via `create-media-from-file` — confirm the foal-style success path: tool returns `{ message, name, id }` and the media item exists in the backoffice.
- [ ] Sanity-check existing `create-media` flows (URL upload, base64 upload) still work and were not regressed.
- [ ] Spot-check non-image media types (Article / File) routed through `create-media-from-file`.

## Follow-ups
- Add `_meta?: Record<string, unknown>` to `ToolDefinition` in `@umbraco-cms/mcp-server-sdk` and forward it in `@umbraco-cms/mcp-hosted`'s `registerTool` call, then collapse this back into the media collection.
- Decide whether `create-media-from-file` should *replace* the `filePath`/`url` story for the hosted Worker, or remain a sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)