### PR TITLE
ci: group dependabot version updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,21 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     target-branch: dev
     open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     target-branch: dev
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Reconfigures `.github/dependabot.yml` to cut PR noise:

- **Monthly** instead of weekly for both npm and github-actions.
- **Grouped** version updates — one grouped PR per ecosystem (`patterns: ["*"]`, `applies-to: version-updates`) instead of one PR per dependency.
- Version updates continue to target **`dev`** via `target-branch`.

## Routing

`target-branch` only affects *version* updates; **security updates are excluded from it and keep opening individually against the default branch** — so security fixes still land on `main` and flow through the release process. Grouping the security PRs isn't possible alongside `target-branch` (dependabot disallows a second overlapping entry for the same ecosystem/directory, and a `security-updates` group is ignored in a `target-branch` entry), so they remain individual by design.

## Activation note

Dependabot reads `dependabot.yml` from the **default branch**, so this takes effect once `v18/dev` becomes `main`. Targeting `v18/dev` deliberately.

## Follow-up (separate)

The existing weekly version-update PRs on `dev` are being closed so the next monthly run rebuilds them as a single grouped PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)