### PR TITLE
chore: upgrade Umbraco to 18.0.0 final

### DIFF
--- a/.claude/commands/upgrade-umbraco.md
+++ b/.claude/commands/upgrade-umbraco.md
@@ -64,7 +64,7 @@ Wait until `https://localhost:44391/umbraco` responds. Because the DB is new, th
 ### 5. Regenerate the OpenAPI client
 
 ```bash
-npm run generate       # orval reads http://localhost:56472/umbraco/swagger/management/swagger.json
+npm run generate       # orval reads http://localhost:56472/umbraco/openapi/management.json
 npm run compile        # catch type-level breakages immediately
 ```
 

--- a/demo-site-template/demo-site-template.csproj
+++ b/demo-site-template/demo-site-template.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="clean" Version="8.0.0-rc1" />
-    <PackageReference Include="Umbraco.Cms" Version="18.0.0-rc3" />
-    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.0.0-rc3" />
+    <PackageReference Include="Umbraco.Cms" Version="18.0.0" />
+    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.0.0" />
     <PackageReference Include="Umbraco.ExaminePDF" Version="18.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>

--- a/src/umb-management-api/tools/manifest/__tests__/__snapshots__/get-manifest-tools.test.ts.snap
+++ b/src/umb-management-api/tools/manifest/__tests__/__snapshots__/get-manifest-tools.test.ts.snap
@@ -9,7 +9,7 @@ exports[`manifest tools get-manifest-manifest should get all manifests 1`] = `
         "extensions": [],
         "id": null,
         "name": "@umbraco-cms/backoffice",
-        "version": "18.0.0-rc3",
+        "version": "18.0.0",
       },
       {
         "extensions": [
@@ -33,7 +33,7 @@ exports[`manifest tools get-manifest-manifest-private should get private manifes
         "extensions": [],
         "id": null,
         "name": "@umbraco-cms/backoffice",
-        "version": "18.0.0-rc3",
+        "version": "18.0.0",
       },
       {
         "extensions": [

--- a/src/umb-management-api/tools/models-builder/__tests__/__snapshots__/get-models-builder-dashboard.test.ts.snap
+++ b/src/umb-management-api/tools/models-builder/__tests__/__snapshots__/get-models-builder-dashboard.test.ts.snap
@@ -10,7 +10,7 @@ exports[`get-models-builder-dashboard should get the models builder dashboard 1`
     "modelsNamespace": "Umbraco.Cms.Web.Common.PublishedModels",
     "outOfDateModels": false,
     "trackingOutOfDateModels": false,
-    "version": "18.0.0-rc3+cb23c84",
+    "version": "18.0.0+c087ce9",
   },
 }
 `;


### PR DESCRIPTION
## Summary

Upgrades the demo-site from **Umbraco 18.0.0-rc3 → 18.0.0 final**.

- Bumps `Umbraco.Cms` and `Umbraco.Cms.DevelopmentMode.Backoffice` to `18.0.0`.
- `Umbraco.ExaminePDF` was already on `18.0.0`; `clean` left at `8.0.0-rc1` (no stable 8.x yet — it tracks Umbraco 18).

## API impact

**None.** The regenerated Orval client is byte-identical to `v18/dev` — zero new endpoints, zero removed endpoints, no schema changes. rc3 → final is a no-op at the management API level.

## Test results

Full integration suite: **2383 passed, 13 skipped**. The only failures were 3 snapshots embedding the build version string (`18.0.0-rc3+…` → `18.0.0+…`) in the manifest and models-builder dashboard responses — updated in this PR.

## Doc fix

Corrected a stale comment in `.claude/commands/upgrade-umbraco.md`: on Umbraco 18 Orval reads the management OpenAPI document at `/umbraco/openapi/management.json`, not the old `/umbraco/swagger/management/swagger.json` path. (The Orval config itself was already on the new URL.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)