### PR TITLE
ci: release v17 LTS line from v17/main under lts-17 tag

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - v17/main
     - feature/*
 
 pool:
@@ -49,7 +50,7 @@ stages:
 
 - stage: Deploy_Npm
   displayName: Npm release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/v17/main'))
   dependsOn:
     - BuildAndTest
   jobs:
@@ -98,15 +99,26 @@ stages:
             tar -tf "${files[0]}" | grep package/package.json | head -1 | xargs tar -xf "${files[0]}" --strip-components=1
             version=$(node -p "require('./package.json').version")
 
-            # Determine tag based on version
+            # Determine release channel from version
             if [[ "${version}" == *"alpha"* ]]; then
-              tag="alpha"
+              channel="alpha"
             elif [[ "${version}" == *"beta"* ]]; then
-              tag="beta"
+              channel="beta"
             elif [[ "${version}" == *"rc"* ]]; then
-              tag="rc"
+              channel="rc"
             else
-              tag="latest"
+              channel="latest"
+            fi
+
+            # Map channel to dist-tag, scoping the v17 line to lts-17*
+            if [[ "${BUILD_SOURCEBRANCH}" == "refs/heads/v17/main" ]]; then
+              if [ "$channel" = "latest" ]; then
+                tag="lts-17"
+              else
+                tag="lts-17-${channel}"
+              fi
+            else
+              tag="$channel"
             fi
 
             echo "Publishing version ${version} with tag ${tag}"

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -3,6 +3,7 @@ trigger:
     include:
     - main
     - v17/main
+    - v17/dev
     - feature/*
 
 pool:


### PR DESCRIPTION
## What

Wires the Azure release pipeline so the **v17 LTS line** can publish from `v17/main`, without disturbing the current 18.x line.

- Add `v17/main` to the CI trigger branches.
- Allow the `Deploy_Npm` stage to run for `v17/main` as well as `main`.
- Branch-aware dist-tagging:
  - `main` → `latest` / `rc` / `beta` / `alpha` (unchanged)
  - `v17/main` → `lts-17` (stable), `lts-17-rc`, `lts-17-beta`

## Why

npm's `latest` is a moving pointer to the *most recent* stable publish, **not** the highest version. A stable 17.x published as `latest` would demote 18.x as the default `npm install`. Publishing the v17 line under `lts-17` keeps `latest` on the current major. Consumers follow v17 with:

```
npx -y @umbraco-cms/mcp-dev@lts-17
```

…and float to the newest 17.x automatically — no config changes per release.

## Notes

- The **MCP Registry** stage is intentionally left **main-only** — there's a single server entry in the registry and it should keep tracking the current major.
- To actually cut a release, bump `package.json` + `server.json` (version and `packages[0].version`) on `v17/main` to the new 17.x; `17.4.2` is already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)