### PR TITLE
Merge v17/main into v17/dev

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - v17/main
     - feature/*
 
 pool:
@@ -49,7 +50,7 @@ stages:
 
 - stage: Deploy_Npm
   displayName: Npm release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/v17/main'))
   dependsOn:
     - BuildAndTest
   jobs:
@@ -98,15 +99,26 @@ stages:
             tar -tf "${files[0]}" | grep package/package.json | head -1 | xargs tar -xf "${files[0]}" --strip-components=1
             version=$(node -p "require('./package.json').version")
 
-            # Determine tag based on version
+            # Determine release channel from version
             if [[ "${version}" == *"alpha"* ]]; then
-              tag="alpha"
+              channel="alpha"
             elif [[ "${version}" == *"beta"* ]]; then
-              tag="beta"
+              channel="beta"
             elif [[ "${version}" == *"rc"* ]]; then
-              tag="rc"
+              channel="rc"
             else
-              tag="latest"
+              channel="latest"
+            fi
+
+            # Map channel to dist-tag, scoping the v17 line to lts-17*
+            if [[ "${BUILD_SOURCEBRANCH}" == "refs/heads/v17/main" ]]; then
+              if [ "$channel" = "latest" ]; then
+                tag="lts-17"
+              else
+                tag="lts-17-${channel}"
+              fi
+            else
+              tag="$channel"
             fi
 
             echo "Publishing version ${version} with tag ${tag}"

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -3,6 +3,7 @@ trigger:
     include:
     - main
     - v17/main
+    - v17/dev
     - feature/*
 
 pool:


### PR DESCRIPTION
Syncs `v17/dev` with `v17/main` so the v17 integration branch is up to date.

Brings across the release-pipeline wiring from #274:
- `v17/main` releases the v17 line under the `lts-17` dist-tag
- `v17/dev` builds for validation (no release)

No divergence on the `v17/dev` side — this is a clean catch-up of `build/azure-pipelines.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)