### PR TITLE
ci: fail the release stage when npm publish fails

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -123,7 +123,10 @@ stages:
             fi
 
             echo "Publishing version ${version} with tag ${tag}"
-            npm publish "${files[0]}" --tag $tag --access public
+            if ! npm publish "${files[0]}" --tag $tag --access public; then
+              echo "##vso[task.logissue type=error]npm publish failed for version ${version}"
+              exit 1
+            fi
 
             # Set output variable for MCP Registry stage
             if [ "$tag" = "latest" ]; then


### PR DESCRIPTION
## What
Check `npm publish`'s exit code explicitly and fail the stage if it errors.

## Why
The publish step's exit code was taken from the trailing `isStable` echo, so a failed `npm publish` (403 on republish, auth/network errors) was **masked** and the stage reported success. Observed on the #274 merge: the `17.4.2` publish hit a 403 but the stage went green.

## Heads-up on merge behaviour
After this lands, merging to `v17/main` **without** a version bump will make the release stage go **red** (it genuinely fails to publish). To cut a real release, bump `package.json` + `server.json` (version and `packages[0].version`) above `17.4.2` in the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)