### PR TITLE
Merge v17/main into v17/dev (publish hardening)

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -123,7 +123,10 @@ stages:
             fi
 
             echo "Publishing version ${version} with tag ${tag}"
-            npm publish "${files[0]}" --tag $tag --access public
+            if ! npm publish "${files[0]}" --tag $tag --access public; then
+              echo "##vso[task.logissue type=error]npm publish failed for version ${version}"
+              exit 1
+            fi
 
             # Set output variable for MCP Registry stage
             if [ "$tag" = "latest" ]; then


### PR DESCRIPTION
Syncs `v17/dev` with `v17/main`, bringing across the publish hardening from #276 (fail the release stage when `npm publish` fails).

Pipeline-only change; `v17/dev` builds but does not release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)