### PR TITLE
ci: run test suite and evals on the v17 line

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, v17/main, v17/dev]
 
 jobs:
   test:
@@ -132,7 +132,8 @@ jobs:
   evals:
     name: LLM Eval Tests
     if: >-
-      github.event.pull_request.base.ref == 'main' &&
+      (github.event.pull_request.base.ref == 'main' ||
+       github.event.pull_request.base.ref == 'v17/main') &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Problem

The `Test` GitHub workflow (`.github/workflows/test.yml`) only triggers on:

```yaml
on:
  pull_request:
    branches: [main, dev]
```

Neither `v17/main` nor `v17/dev` is listed, so **no GitHub CI runs on any PR into the v17 branches** — not integration tests, not Playwright E2E, and not the LLM evals. Only the Azure pipeline runs, and its `BuildAndTest` stage is build + `npm pack` only (no tests).

Concretely: the new v17 LTS release pipeline publishes to npm (`lts-17` tag) from `v17/main`, but releases into `v17/main` get **none of the eval / integration gating** that `main` releases get.

On top of that, the `evals` job condition was hardcoded to the `main` base:

```yaml
if: base.ref == 'main' && startsWith(head.ref, 'release/')
```

so it would skip `release/* → v17/main` even if the workflow did trigger.

## Fix

- Add `v17/main` and `v17/dev` to the `pull_request` branch filter → the `test` job (integration + E2E) now runs on v17 PRs.
- Extend the `evals` job condition to also fire for `release/*` PRs into `v17/main`, mirroring the existing `release/* → main` behaviour.

## Why it must land on v17/main

For `pull_request` events, GitHub reads the workflow definition from the **base branch**. So for evals to gate a `release/17.x.y → v17/main` PR, the updated `test.yml` has to exist on `v17/main`. This PR targets `v17/dev`, which feeds `v17/main`.

## Assumption

v17 version releases use `release/X.Y.Z` head branches (consistent with the historical `release/* → main` releases). The eval gate keeps the `release/` prefix requirement, so routine `chore/*` merges into `v17/main` won't burn eval API budget — only version-release PRs will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)