### PR TITLE
fix: restore hmac in imaging resize-url snapshot

### DIFF
--- a/src/umb-management-api/tools/imaging/__tests__/__snapshots__/get-imaging-resize-urls.test.ts.snap
+++ b/src/umb-management-api/tools/imaging/__tests__/__snapshots__/get-imaging-resize-urls.test.ts.snap
@@ -10,7 +10,7 @@ exports[`get-imaging-resize-urls should generate resize URLs for specific media 
         "urlInfos": [
           {
             "culture": null,
-            "url": "https://localhost:44391/media/0ofdvcwj/chairs-lamps.jpg?width=200&height=200",
+            "url": "https://localhost:44391/media/0ofdvcwj/chairs-lamps.jpg?width=200&height=200&hmac=NORMALIZED",
           },
         ],
       },


### PR DESCRIPTION
## Problem

PR #278 (the 17.5.0 upgrade) accepted a snapshot change that stripped `&hmac=NORMALIZED` from `get-imaging-resize-urls`. That was an artifact of the **reused local dev database**, which lacked the imaging HMAC secret — so locally the resize URLs came back unsigned.

A clean 17.5.0 install (including CI, and any real user) **signs resize URLs with an hmac**, and the test already normalizes the value via `/hmac=[a-f0-9]+/ → hmac=NORMALIZED`. The accepted snapshot therefore broke CI on the next clean run (caught on the `release/17.5.0 → v17/main` PR #280).

## Fix

Restore `&hmac=NORMALIZED` in the snapshot to match canonical behaviour. One line; same fix already applied on the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)