### PR TITLE
chore: remove unused axios dependency (18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/yargs": "^17.0.33",
         "@umbraco-cms/mcp-hosted": "^1.0.0-beta.31",
         "@umbraco-cms/mcp-server-sdk": "^1.0.0-beta.31",
-        "axios": "^1.8.4",
         "dotenv": "^16.5.0",
         "form-data": "^4.0.4",
         "mime-types": "^3.0.1",
@@ -3659,17 +3658,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
-    "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -5105,26 +5093,6 @@
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/foreground-child": {
@@ -8084,15 +8052,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode.js": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/yargs": "^17.0.33",
     "@umbraco-cms/mcp-hosted": "^1.0.0-beta.31",
     "@umbraco-cms/mcp-server-sdk": "^1.0.0-beta.31",
-    "axios": "^1.8.4",
     "dotenv": "^16.5.0",
     "form-data": "^4.0.4",
     "mime-types": "^3.0.1",

--- a/src/umb-management-api/tools/data-type/get/get-data-type-schema.ts
+++ b/src/umb-management-api/tools/data-type/get/get-data-type-schema.ts
@@ -3,11 +3,11 @@ import { getDataTypeByIdSchemaParams } from "@/umb-management-api/umbracoManagem
 import { z } from "zod";
 import {
   type ToolDefinition,
+  type HttpResponse,
   CAPTURE_RAW_HTTP_RESPONSE,
   createToolResult,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
-import { AxiosResponse } from "axios";
 
 // Custom output schema - the generated one is too strict for JSON Schema content
 export const dataTypeSchemaOutputSchema = z.object({
@@ -34,7 +34,7 @@ IMPORTANT: Use this tool BEFORE creating data types to understand the expected c
     const response = (await client.getDataTypeByIdSchema(
       id,
       CAPTURE_RAW_HTTP_RESPONSE
-    )) as unknown as AxiosResponse;
+    )) as unknown as HttpResponse;
     return createToolResult(response.data ?? {});
   },
 } satisfies ToolDefinition<typeof getDataTypeByIdSchemaParams.shape, typeof outputSchema.shape>;

--- a/src/umb-management-api/tools/document/get/get-document-type-schema.ts
+++ b/src/umb-management-api/tools/document/get/get-document-type-schema.ts
@@ -3,11 +3,11 @@ import { getDocumentTypeByIdSchemaParams } from "@/umb-management-api/umbracoMan
 import { z } from "zod";
 import {
   type ToolDefinition,
+  type HttpResponse,
   CAPTURE_RAW_HTTP_RESPONSE,
   createToolResult,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
-import { AxiosResponse } from "axios";
 
 // Wrap the JSON Schema in an object so MCP structured output validation works
 export const documentTypeSchemaOutputSchema = z.object({
@@ -33,7 +33,7 @@ IMPORTANT: Use this tool BEFORE creating documents to understand the expected pr
     const response = (await client.getDocumentTypeByIdSchema(
       id,
       CAPTURE_RAW_HTTP_RESPONSE
-    )) as unknown as AxiosResponse;
+    )) as unknown as HttpResponse;
     return createToolResult({ schema: response.data });
   },
 } satisfies ToolDefinition<typeof getDocumentTypeByIdSchemaParams.shape, typeof outputSchema.shape>;

--- a/src/umb-management-api/tools/log-viewer/__tests__/helpers/log-viewer-test-helper.ts
+++ b/src/umb-management-api/tools/log-viewer/__tests__/helpers/log-viewer-test-helper.ts
@@ -17,7 +17,7 @@ export class LogViewerTestHelper {
 
   static async cleanup(name: string): Promise<void> {
     // Check if the saved search exists before trying to delete it
-    // This avoids 404 errors that get logged by the axios client
+    // This avoids 404 errors that get logged by the HTTP client
     const existingSearch = await this.findSavedSearch(name);
     if (existingSearch) {
       const client = UmbracoManagementClient.getClient();

--- a/src/umb-management-api/tools/media/get/get-media-type-schema.ts
+++ b/src/umb-management-api/tools/media/get/get-media-type-schema.ts
@@ -3,11 +3,11 @@ import { getMediaTypeByIdSchemaParams } from "@/umb-management-api/umbracoManage
 import { z } from "zod";
 import {
   type ToolDefinition,
+  type HttpResponse,
   CAPTURE_RAW_HTTP_RESPONSE,
   createToolResult,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
-import { AxiosResponse } from "axios";
 
 // Wrap the JSON Schema in an object so MCP structured output validation works
 const outputSchema = z.object({
@@ -29,7 +29,7 @@ IMPORTANT: Use this tool BEFORE creating media to understand the expected proper
   slices: ['read'],
   handler: async ({ id }: { id: string }) => {
     const client = UmbracoManagementClient.getClient();
-    const response = await client.getMediaTypeByIdSchema(id, CAPTURE_RAW_HTTP_RESPONSE) as unknown as AxiosResponse;
+    const response = await client.getMediaTypeByIdSchema(id, CAPTURE_RAW_HTTP_RESPONSE) as unknown as HttpResponse;
     return createToolResult({ schema: response.data });
   },
 } satisfies ToolDefinition<typeof getMediaTypeByIdSchemaParams.shape, typeof outputSchema.shape>;

--- a/src/umb-management-api/tools/member/get/get-member-type-schema.ts
+++ b/src/umb-management-api/tools/member/get/get-member-type-schema.ts
@@ -3,11 +3,11 @@ import { getMemberTypeByIdSchemaParams } from "@/umb-management-api/umbracoManag
 import { z } from "zod";
 import {
   type ToolDefinition,
+  type HttpResponse,
   CAPTURE_RAW_HTTP_RESPONSE,
   createToolResult,
   withStandardDecorators,
 } from "@umbraco-cms/mcp-server-sdk";
-import { AxiosResponse } from "axios";
 
 // Wrap the JSON Schema in an object so MCP structured output validation works
 const outputSchema = z.object({
@@ -29,7 +29,7 @@ IMPORTANT: Use this tool BEFORE creating members to understand the expected prop
   slices: ['read'],
   handler: async ({ id }: { id: string }) => {
     const client = UmbracoManagementClient.getClient();
-    const response = await client.getMemberTypeByIdSchema(id, CAPTURE_RAW_HTTP_RESPONSE) as unknown as AxiosResponse;
+    const response = await client.getMemberTypeByIdSchema(id, CAPTURE_RAW_HTTP_RESPONSE) as unknown as HttpResponse;
     return createToolResult({ schema: response.data });
   },
 } satisfies ToolDefinition<typeof getMemberTypeByIdSchemaParams.shape, typeof outputSchema.shape>;


### PR DESCRIPTION
## Summary

Same change as #289 (v17 line), applied to the 18 line (`dev`).

The HTTP client was migrated to `@umbraco-cms/mcp-server-sdk`, which issues requests via `fetch` and exposes its own `HttpResponse` type. `axios` was left declared in `package.json` but is no longer used at runtime — it was referenced only as a **type-only** cast (`AxiosResponse`) in four `*-schema` tool files.

This PR:
- Removes `axios` from `package.json` and the lockfile (0 references remain)
- Swaps the `AxiosResponse` casts for the SDK's exported `HttpResponse` type (identical `.data` shape) in the document, data-type, media, and member schema tools — `HttpResponse` is already used across ~30 other tool files on this line
- Fixes a stale comment in the log-viewer test helper

## Why

Removing axios from the lockfile resolves the axios Dependabot alerts at the root, rather than just bumping the version.

## Left untouched

The Orval `client: "axios"` generator setting stays as-is. It's a style selector fully intercepted by the mutator (`api/client.ts`), which delegates to the SDK — the generated client contains **zero** axios imports/types.

## Verification

- `npm ls axios` → empty (gone from tree)
- `node_modules/axios` → gone
- `npm run compile` (`tsc --noEmit`) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)