### PR TITLE
Merge v17/main to v17/dev (17.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.5.0",
+    "version": "17.5.1",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.5.0",
+      "version": "17.5.1",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/docs/analysis/api-endpoints-analysis.md
+++ b/docs/analysis/api-endpoints-analysis.md
@@ -1,18 +1,17 @@
 # API Endpoints Analysis
 
-**Last Updated**: 2025-12-03
+**Last Updated**: 2026-07-02
 
 ## Summary
 
 | Collection | Tool Count |
 |------------|------------|
-| .claude | 0 |
 | culture | 1 |
-| data-type | 22 |
+| data-type | 26 |
 | dictionary | 10 |
-| document | 45 |
+| document | 48 |
 | document-blueprint | 16 |
-| document-type | 27 |
+| document-type | 31 |
 | document-version | 4 |
 | health | 4 |
 | imaging | 1 |
@@ -20,11 +19,11 @@
 | language | 7 |
 | log-viewer | 9 |
 | manifest | 3 |
-| media | 31 |
-| media-type | 23 |
-| member | 13 |
+| media | 34 |
+| media-type | 26 |
+| member | 15 |
 | member-group | 7 |
-| member-type | 13 |
+| member-type | 15 |
 | models-builder | 3 |
 | partial-view | 15 |
 | property-type | 1 |
@@ -37,14 +36,14 @@
 | static-file | 4 |
 | stylesheet | 13 |
 | tag | 1 |
-| template | 13 |
+| template | 14 |
 | temporary-file | 4 |
-| user | 15 |
+| user | 17 |
 | user-data | 5 |
 | user-group | 8 |
 | webhook | 9 |
 
-**Total MCP Tools**: 358
+**Total MCP Tools**: 382
 
 ## Tools by Collection
 
@@ -52,7 +51,7 @@
 
 - `get-culture`
 
-### data-type (22)
+### data-type (26)
 
 - `copy-data-type`
 - `create-data-type`
@@ -63,13 +62,17 @@
 - `get-all-data-types`
 - `get-data-type`
 - `get-data-type-ancestors`
+- `get-data-type-ancestors-batch`
+- `get-data-type-batch`
 - `get-data-type-children`
 - `get-data-type-configuration`
 - `get-data-type-folder`
-- `get-data-type-property-editor-template`
 - `get-data-type-root`
+- `get-data-type-schema`
+- `get-data-type-schemas`
 - `get-data-type-search`
 - `get-data-type-siblings`
+- `get-data-type-tree-search`
 - `get-data-types-by-id-array`
 - `get-references-data-type`
 - `is-used-data-type`
@@ -90,7 +93,7 @@
 - `move-dictionary-item`
 - `update-dictionary-item`
 
-### document (45)
+### document (48)
 
 - `copy-document`
 - `create-document`
@@ -101,6 +104,7 @@
 - `empty-recycle-bin`
 - `get-collection-document-by-id`
 - `get-document-ancestors`
+- `get-document-ancestors-batch`
 - `get-document-are-referenced`
 - `get-document-audit-log`
 - `get-document-available-segment-options`
@@ -111,12 +115,12 @@
 - `get-document-configuration`
 - `get-document-domains`
 - `get-document-notifications`
-- `get-document-property-value-template`
 - `get-document-public-access`
 - `get-document-publish`
 - `get-document-recycle-bin-siblings`
 - `get-document-root`
 - `get-document-siblings`
+- `get-document-type-schema`
 - `get-document-urls`
 - `get-item-document`
 - `get-recycle-bin-document-children`
@@ -135,7 +139,9 @@
 - `search-document`
 - `sort-document`
 - `unpublish-document`
+- `update-block-property`
 - `update-document`
+- `update-document-properties`
 - `validate-document`
 
 ### document-blueprint (16)
@@ -157,7 +163,7 @@
 - `update-document-blueprint`
 - `update-document-blueprint-folder`
 
-### document-type (27)
+### document-type (31)
 
 - `copy-document-type`
 - `create-document-type`
@@ -168,8 +174,11 @@
 - `get-all-document-types`
 - `get-document-type-allowed-at-root`
 - `get-document-type-allowed-children`
+- `get-document-type-allowed-parents`
 - `get-document-type-ancestors`
+- `get-document-type-ancestors-batch`
 - `get-document-type-available-compositions`
+- `get-document-type-batch`
 - `get-document-type-blueprint`
 - `get-document-type-by-id`
 - `get-document-type-children`
@@ -178,6 +187,7 @@
 - `get-document-type-folder`
 - `get-document-type-root`
 - `get-document-type-siblings`
+- `get-document-type-tree-search`
 - `get-document-types-by-id-array`
 - `get-icons`
 - `move-document-type`
@@ -239,9 +249,10 @@
 - `get-manifest-manifest-private`
 - `get-manifest-manifest-public`
 
-### media (31)
+### media (34)
 
 - `create-media`
+- `create-media-folder`
 - `create-media-multiple`
 - `delete-media`
 - `delete-media-from-recycle-bin`
@@ -249,6 +260,7 @@
 - `empty-media-recycle-bin`
 - `get-collection-media`
 - `get-media-ancestors`
+- `get-media-ancestors-batch`
 - `get-media-are-referenced`
 - `get-media-audit-log`
 - `get-media-by-id`
@@ -260,6 +272,7 @@
 - `get-media-recycle-bin-siblings`
 - `get-media-root`
 - `get-media-siblings`
+- `get-media-type-schema`
 - `get-media-urls`
 - `get-recycle-bin-media-children`
 - `get-recycle-bin-media-original-parent`
@@ -273,7 +286,7 @@
 - `validate-media`
 - `validate-media-update`
 
-### media-type (23)
+### media-type (26)
 
 - `copy-media-type`
 - `create-media-type`
@@ -284,8 +297,11 @@
 - `get-item-media-type`
 - `get-media-type-allowed-at-root`
 - `get-media-type-allowed-children`
+- `get-media-type-allowed-parents`
 - `get-media-type-ancestors`
+- `get-media-type-ancestors-batch`
 - `get-media-type-available-compositions`
+- `get-media-type-batch`
 - `get-media-type-by-id`
 - `get-media-type-by-ids`
 - `get-media-type-children`
@@ -299,17 +315,19 @@
 - `update-media-type`
 - `update-media-type-folder`
 
-### member (13)
+### member (15)
 
 - `create-member`
 - `delete-member`
 - `find-member`
 - `get-item-member-search`
 - `get-member`
+- `get-member-ancestors-batch`
 - `get-member-are-referenced`
 - `get-member-by-id-referenced-by`
 - `get-member-by-id-referenced-descendants`
 - `get-member-configuration`
+- `get-member-type-schema`
 - `get-members-by-id-array`
 - `update-member`
 - `validate-member`
@@ -325,13 +343,15 @@
 - `get-member-group-root`
 - `update-member-group`
 
-### member-type (13)
+### member-type (15)
 
 - `copy-member-type`
 - `create-member-type`
 - `delete-member-type`
 - `get-member-type`
+- `get-member-type-ancestors-batch`
 - `get-member-type-available-compositions`
+- `get-member-type-batch`
 - `get-member-type-by-id`
 - `get-member-type-composition-references`
 - `get-member-type-configuration`
@@ -442,13 +462,14 @@
 
 - `get-tags`
 
-### template (13)
+### template (14)
 
 - `create-template`
 - `delete-template`
 - `execute-template-query`
 - `get-template`
 - `get-template-ancestors`
+- `get-template-ancestors-batch`
 - `get-template-children`
 - `get-template-configuration`
 - `get-template-query-settings`
@@ -465,9 +486,10 @@
 - `get-temporary-file`
 - `get-temporary-file-configuration`
 
-### user (15)
+### user (17)
 
 - `delete-user-avatar-by-id`
+- `delete-user-current-avatar`
 - `find-user`
 - `get-item-user`
 - `get-user`
@@ -480,6 +502,7 @@
 - `get-user-current-permissions`
 - `get-user-current-permissions-document`
 - `get-user-current-permissions-media`
+- `update-user-current-profile`
 - `upload-user-avatar-by-id`
 - `upload-user-current-avatar`
 
@@ -516,6 +539,6 @@
 
 ## Notes
 
-- This count includes only files that contain `CreateUmbracoTool` or `CreateUmbracoResource`
+- This count includes only files that contain `ToolDefinition` and `withStandardDecorators`
 - Excludes `index.ts` files and test files (`__tests__` directories)
 - Helper files, constants, and utilities are not counted

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.5.0",
+  "version": "17.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.5.0",
+      "version": "17.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.5.0",
+  "version": "17.5.1",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.5.0",
+  "version": "17.5.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.5.0",
+      "version": "17.5.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Post-release back-merge of `v17/main` into `v17/dev` following the 17.5.1 release, keeping the two branches in sync.

Brings across:
- `release: 17.5.1` version bump (package.json, package-lock.json, server.json, .claude-plugin/marketplace.json)
- `docs: regenerate API endpoints tool report` (#286) — committed to v17/main and not previously on v17/dev

No conflicts. Merge with a **merge commit** (not squash), per the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)