### PR TITLE
ci: add GitHub release automation to the v17 pipeline

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -138,6 +138,52 @@ stages:
           displayName: Push to npm with dynamic tagging
           workingDirectory: $(Pipeline.Workspace)/npm-package
 
+- stage: Create_GitHub_Release
+  displayName: GitHub release
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/v17/main'))
+  dependsOn:
+    - Deploy_Npm
+  jobs:
+    - job: Release
+      displayName: Create GitHub Release
+      variables:
+        isStableRelease: $[ stageDependencies.Deploy_Npm.Publish.outputs['npmPublish.isStable'] ]
+      steps:
+        - checkout: self
+        - task: NodeTool@0
+          displayName: 'Use Node.js $(nodeVersion)'
+          inputs:
+            versionSpec: '$(nodeVersion)'
+        - script: |
+            VERSION=$(node -p "require('./package.json').version")
+            TAG="v${VERSION}"
+
+            # Determine if this is a prerelease
+            if [ "$(isStableRelease)" = "true" ]; then
+              PRERELEASE_FLAG=""
+            else
+              PRERELEASE_FLAG="--prerelease"
+            fi
+
+            # Generate release notes from commits since last tag
+            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+            if [ -n "$LAST_TAG" ]; then
+              NOTES=$(git log ${LAST_TAG}..HEAD --oneline --no-merges | sed 's/^/- /')
+            else
+              NOTES="Initial release"
+            fi
+
+            echo "Creating GitHub release ${TAG}"
+            gh release create "${TAG}" \
+              --target v17/main \
+              --title "${TAG}" \
+              --notes "${NOTES}" \
+              --latest=false \
+              ${PRERELEASE_FLAG}
+          displayName: 'Create GitHub Release'
+          env:
+            GH_TOKEN: $(MCP_REGISTRY_GITHUB_TOKEN)
+
 - stage: Deploy_MCP_Registry
   displayName: MCP Registry release
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))


### PR DESCRIPTION
## Summary

Ports the automatic GitHub-release stage from #240 (the 18-line PR) to the **v17** pipeline, adapted for the LTS line.

Fills the gap this session exposed: v17 releases publish to npm and get a git tag, but the **GitHub Release was never created automatically** — it had to be done by hand for 17.5.1.

## Adaptations vs #240
| | #240 (18 / `dev`→`main`) | This PR (17 / `v17/dev`→`v17/main`) |
|---|---|---|
| Trigger | `refs/heads/main` | `refs/heads/v17/main` |
| `--target` | `main` | `v17/main` |
| `--latest` | default (becomes latest) | **`--latest=false`** |

The `--latest=false` is the key difference: v17 is the LTS line, so a v17 release must **not** override the current major (18.x) as the "latest" GitHub release.

Same stable/prerelease logic and note generation as #240.

## Notes
- Pipeline-only change (`build/azure-pipelines.yml`, +46 lines). YAML validated locally.
- Takes effect from the next v17 release once this reaches `v17/main`.
- Companion to #240 (18 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)