### PR TITLE
chore: build on dev (+ v*/dev, v*/main) so dev deploys fire

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -2,6 +2,9 @@ trigger:
   branches:
     include:
     - main
+    - dev
+    - v*/main
+    - v*/dev
     - feature/*
 
 pool:


### PR DESCRIPTION
## Why
The hosted-MCP **deploy** fires off the **build pipeline completing** (pipeline-completion trigger in the infra repo). CI triggers are per-branch, and this repo's `build/azure-pipelines.yml` trigger on the **v18 line (`dev`/`main`) is `main, feature/*`** — it never lists `dev`. So a push/merge to `dev` doesn't build → no completion → the v18 **dev** worker never deploys.

v17 already works precisely because the v17 branches' trigger lists `v17/dev` + `v17/main`. This just gives the v18 line the same treatment.

## Change
```yaml
trigger:
  branches:
    include: [ main, dev, v*/main, v*/dev, feature/* ]
```
- Adds `dev` (the missing piece) and generalises the explicit v17 entries to `v*/dev` / `v*/main` so current + future LTS lines build consistently and match the infra deploy trigger.
- **Build + test only on `dev`** — the npm/MCP-registry publish stages stay gated to `main` / `v17/main`, so this doesn't publish anything on dev.

## Effect
A push to `dev` now builds → the infra deploy's completion trigger fires → deploys `cms_developer_18` to the **dev** worker (`cms.developer.18.dev.mcp.umbraco.ai`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)