### PR TITLE
ci: add loop-dispatch caller workflow (dev)

### DIFF
--- a/.github/workflows/loop-dispatch.yml
+++ b/.github/workflows/loop-dispatch.yml
@@ -1,0 +1,35 @@
+# LOCKED template — the per-repo caller for the loop-dispatch reusable workflow.
+# Commit verbatim to each target repo as `.github/workflows/loop-dispatch.yml`.
+# It declares every loop event (issue labels + PR labels — Actions has no
+# event-type-mixing limit, unlike the routines UI) and calls the reusable workflow in
+# umbraco-mcp-ops, which routes at the edge and fires the repo's routine only on a real
+# match. No per-repo edits: the two secrets carry everything repo-specific.
+#
+# PR labels use `pull_request_target`, NOT `pull_request`: `pull_request` resolves the
+# workflow from the PR's BASE branch, and our loop PRs target `dev` (a non-default
+# branch), where GitHub does not fire the `labeled` trigger. `pull_request_target` always
+# runs from the base repo's DEFAULT branch, WITH secrets, regardless of the PR's base — so
+# `auto-merge` / `auto-rework` fire on dev-based PRs. It's safe here because this caller
+# never checks out or executes PR head code — it only forwards event metadata to the
+# reusable workflow, which routes on the payload and checks out trusted mcp-ops.
+#
+# Requires two secrets on the repo (or the org):
+#   LOOP_DISPATCH_FIRE_URL  — the routine's Fire URL (Routines UI → Call via API)
+#   LOOP_DISPATCH_TOKEN     — the token generated for that routine
+name: loop-dispatch
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  dispatch:
+    uses: hifi-phil/umbraco-mcp-ops/.github/workflows/loop-dispatch.yml@main
+    # Pass explicitly — NOT `secrets: inherit`. inherit only forwards secrets when the
+    # caller and the reusable workflow share an org/enterprise; these repos are in
+    # different owners (umbraco vs hifi-phil), so inherit would forward nothing.
+    secrets:
+      LOOP_DISPATCH_FIRE_URL: ${{ secrets.LOOP_DISPATCH_FIRE_URL }}
+      LOOP_DISPATCH_TOKEN: ${{ secrets.LOOP_DISPATCH_TOKEN }}


### PR DESCRIPTION
Adds the committed loop-dispatch caller workflow — the last piece to wire Dev into the loop system (matching Editor).

- Subscribes to `issues.labeled` + `pull_request_target.labeled` (PR labels via `pull_request_target` so they fire on dev-based PRs).
- Calls the shared reusable workflow in `hifi-phil/umbraco-mcp-ops@main`, passing the two repo secrets explicitly.
- Routing is decided at the edge by `route-event.sh` — the routine fires only on a real match.

Already in place: labels ✓, routine (`loop-dispatch → Umbraco-CMS-MCP-Dev`, enabled, Fire token generated) ✓, repo secrets ✓. This workflow is all that's left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)