### PR TITLE
Support --sqlite in bootstrap-demo-site.sh (v17 line)

### DIFF
--- a/scripts/bootstrap-demo-site.sh
+++ b/scripts/bootstrap-demo-site.sh
@@ -13,11 +13,26 @@ TEMPLATE_DIR="$PROJECT_DIR/demo-site-template"
 SITE_DIR="$PROJECT_DIR/demo-site"
 
 FORCE=0
+SQLITE=0
 for arg in "$@"; do
   case "$arg" in
     --force) FORCE=1 ;;
+    --sqlite) SQLITE=1 ;;
   esac
 done
+
+# Writes a server-less SQLite appsettings.local.json so Umbraco can boot
+# without SQL Server / Docker.
+write_sqlite_config() {
+  cat > "$SITE_DIR/appsettings.local.json" <<'EOF'
+{
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
+  }
+}
+EOF
+}
 
 if [ ! -d "$TEMPLATE_DIR" ]; then
   echo "Error: $TEMPLATE_DIR does not exist" >&2
@@ -49,7 +64,20 @@ if [ -f "$SITE_DIR/demo-site-template.csproj" ]; then
   mv "$SITE_DIR/demo-site-template.csproj" "$SITE_DIR/demo-site.csproj"
 fi
 
+if [ "$SQLITE" -eq 1 ]; then
+  if [ ! -f "$SITE_DIR/appsettings.local.json" ] || [ "$FORCE" -eq 1 ]; then
+    write_sqlite_config
+    echo "demo-site/appsettings.local.json written for server-less SQLite" >&2
+  else
+    echo "demo-site/appsettings.local.json already exists; leaving untouched (pass --force to overwrite)" >&2
+  fi
+fi
+
 echo "demo-site/ created from demo-site-template/" >&2
 echo "Next steps:" >&2
-echo "  - Write demo-site/appsettings.local.json with your DB connection string" >&2
+if [ "$SQLITE" -eq 1 ]; then
+  echo "  - appsettings.local.json already written for server-less SQLite" >&2
+else
+  echo "  - Write demo-site/appsettings.local.json with your DB connection string" >&2
+fi
 echo "  - Run 'npm run umbraco:start'" >&2


### PR DESCRIPTION
## Summary

Adds `--sqlite` support to `scripts/bootstrap-demo-site.sh` so `npm run umbraco:bootstrap -- --sqlite` writes a server-less SQLite `appsettings.local.json`, letting Umbraco boot with no SQL Server / Docker. This brings Dev's bootstrap script to parity with Editor MCP (`umbraco/Umbraco-CMS-MCP-Editor#60`, mirrored directly from the issue spec since that repo isn't accessible from this session).

## Changes

- Parse `--sqlite` alongside the existing `--force` flag (same `for arg in "$@"` pattern).
- Add `write_sqlite_config()`, writing:
  ```json
  {
    "ConnectionStrings": {
      "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
      "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
    }
  }
  ```
- Call it only when `--sqlite` is passed, and only if `appsettings.local.json` doesn't already exist or `--force` was passed — composes with the script's existing "don't clobber a hand-written config unless --force" behaviour rather than duplicating it.
- Adjust the trailing "Next steps" message so it doesn't tell the user to hand-write the config when `--sqlite` already wrote it.
- No change to default (non-`--sqlite`) behaviour — nothing is written unless the flag is passed.

## Testing (cloud session — no local SQL Server/Umbraco available)

- `bash -n scripts/bootstrap-demo-site.sh` — syntax OK. `shellcheck` is not installed in this session, so it was not run.
- Ran the script directly against the real `demo-site-template/` → `demo-site/` flow:
  - No flags: `demo-site/appsettings.local.json` is **not** written (unchanged default behaviour).
  - `--sqlite`: `demo-site/appsettings.local.json` is written with exactly the JSON above; validated with both `jq` and `node -e "JSON.parse(...)"`.
  - `--sqlite` again (no `--force`) after hand-editing the file: script exits early per the existing "demo-site/ already exists" guard, file left untouched.
  - `--sqlite --force`: file is rewritten to the canonical SQLite config.
- Cleaned up the scratch `demo-site/` afterwards; `git status` is clean aside from the intended diff.
- `npm ci` + `npm run compile` pass (this is a bash-only change; compile is unaffected).
- Security review and code review (manual, since the automated skills' git-diff detection targeted committed history rather than the uncommitted working diff in this session) both came back clean — no findings.

Closes #313


---
_Generated by [Claude Code](https://claude.ai/code/session_01AYD9h36ytZPoo7CRMbtXt7)_