### PR TITLE
feat: support --sqlite in bootstrap-demo-site.sh

### DIFF
--- a/scripts/bootstrap-demo-site.sh
+++ b/scripts/bootstrap-demo-site.sh
@@ -13,11 +13,30 @@ TEMPLATE_DIR="$PROJECT_DIR/demo-site-template"
 SITE_DIR="$PROJECT_DIR/demo-site"
 
 FORCE=0
+SQLITE=0
 for arg in "$@"; do
   case "$arg" in
     --force) FORCE=1 ;;
+    --sqlite) SQLITE=1 ;;
   esac
 done
+
+write_sqlite_config() {
+  local config_file="$SITE_DIR/appsettings.local.json"
+  if [ -f "$config_file" ] && [ "$FORCE" -eq 0 ]; then
+    echo "$config_file already exists; leaving it untouched (pass --force to overwrite)" >&2
+    return 0
+  fi
+  cat > "$config_file" <<'EOF'
+{
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
+  }
+}
+EOF
+  echo "Wrote $config_file (server-less SQLite, no SQL Server needed)" >&2
+}
 
 if [ ! -d "$TEMPLATE_DIR" ]; then
   echo "Error: $TEMPLATE_DIR does not exist" >&2
@@ -26,6 +45,9 @@ fi
 
 if [ -d "$SITE_DIR" ] && [ "$FORCE" -eq 0 ]; then
   echo "demo-site/ already exists; skipping bootstrap (pass --force to overwrite)" >&2
+  if [ "$SQLITE" -eq 1 ]; then
+    write_sqlite_config
+  fi
   exit 0
 fi
 
@@ -50,6 +72,13 @@ if [ -f "$SITE_DIR/demo-site-template.csproj" ]; then
 fi
 
 echo "demo-site/ created from demo-site-template/" >&2
-echo "Next steps:" >&2
-echo "  - Write demo-site/appsettings.local.json with your DB connection string" >&2
-echo "  - Run 'npm run umbraco:start'" >&2
+
+if [ "$SQLITE" -eq 1 ]; then
+  write_sqlite_config
+  echo "Next steps:" >&2
+  echo "  - Run 'npm run umbraco:start'" >&2
+else
+  echo "Next steps:" >&2
+  echo "  - Write demo-site/appsettings.local.json with your DB connection string" >&2
+  echo "  - Run 'npm run umbraco:start'" >&2
+fi


### PR DESCRIPTION
## Summary
- Adds a `--sqlite` flag to `scripts/bootstrap-demo-site.sh` (parity with Editor MCP), which writes a server-less SQLite `appsettings.local.json` to `demo-site/` so Umbraco can boot with no SQL Server / Docker.
- Honours `--force`: an existing `appsettings.local.json` is left untouched unless `--force` is passed.
- Default (non-`--sqlite`) behaviour is unchanged.

## Details
`write_sqlite_config()` writes:
```json
{
  "ConnectionStrings": {
    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
  }
}
```
It's called both on a fresh bootstrap and on a re-run against an already-existing `demo-site/` (in which case only the config file is written, not the whole site), matching the `--force` semantics on the config file specifically.

## Testing
- `bash -n` syntax check passes.
- Manually exercised all four scenarios (fresh bootstrap with `--sqlite`, re-run without `--force` leaves the file untouched, `--force --sqlite` overwrites, default non-sqlite path is unaffected) against a scratch copy of the script with `rsync` swapped for `cp -a` (rsync isn't installed in this sandbox) — all behaved as expected.
- `npm run compile` shows one pre-existing, unrelated `tsconfig.json` deprecation warning (present before this change); no new compile errors.
- Security review: no security-relevant surface — the change only writes a static heredoc to a local file, gated by trusted CLI flags, no command injection or path traversal.
- Code review: manually reviewed for correctness/style; matches the existing script's conventions.

Closes #312

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcDmtugH4pSLkEkvN45eZM)_