### PR TITLE
Fix: broaden pipeline deploy-stage conditions to include v*/main

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -52,7 +52,7 @@ stages:
 
 - stage: Deploy_Npm
   displayName: Npm release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/v'), endsWith(variables['Build.SourceBranch'], '/main'))))
   dependsOn:
     - BuildAndTest
   jobs:
@@ -127,7 +127,7 @@ stages:
 
 - stage: Create_GitHub_Release
   displayName: GitHub release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/v'), endsWith(variables['Build.SourceBranch'], '/main'))))
   dependsOn:
     - Deploy_Npm
   jobs:
@@ -172,7 +172,7 @@ stages:
 
 - stage: Deploy_MCP_Registry
   displayName: MCP Registry release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/v'), endsWith(variables['Build.SourceBranch'], '/main'))))
   dependsOn:
     - Deploy_Npm
   jobs:


### PR DESCRIPTION
## Summary

Fixes #322. v17 LTS releases `17.5.0` and `17.5.1` shipped npm packages, git tags, and GitHub releases, but were never published to the official MCP registry.

**Root cause:** `build/azure-pipelines.yml` gated all three deploy stages (`Deploy_Npm`, `Create_GitHub_Release`, `Deploy_MCP_Registry`) on:

```yaml
condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
```

`17.5.1` shipped from `v17/main`, not `main` (v18 now owns `main`), so all three deploy stages were conditioned out for the LTS-17 line — including the MCP registry publish.

**Fix:** broadened each of the 3 stage-level `condition:` blocks to also match any `refs/heads/v*/main` branch, expressed as `startsWith(..., 'refs/heads/v')` AND `endsWith(..., '/main')` (Azure Pipelines expressions don't support glob wildcards directly):

```yaml
condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), and(startsWith(variables['Build.SourceBranch'], 'refs/heads/v'), endsWith(variables['Build.SourceBranch'], '/main'))))
```

This only touches the deploy-stage gate — the pipeline's `trigger:` block already included `v*/main` and `v*/dev`. The nested `isStableRelease` condition on the `Deploy_MCP_Registry` job's publish step is untouched, so `latest`/dist-tag selection is unaffected and stays on the v18 line.

**Out of scope (per the issue):** backfilling the missing `17.5.0`/`17.5.1` MCP registry entries. This PR only fixes the pipeline so future v17 LTS releases (17.5.2+) publish correctly.

## Validation

- `npm ci`, `npm run build`, and `npm run compile` all pass unchanged — this is a YAML-only change with no application code impact.
- `python3 -c "import yaml; yaml.safe_load(open('build/azure-pipelines.yml'))"` confirms the YAML is well-formed.
- `git diff` confirms only the 3 intended condition lines changed; the unrelated nested `isStableRelease` step condition (~line 183) was left untouched.
- Security review: ran a focused review of the diff. One point was raised — `startsWith('refs/heads/v')` + `endsWith('/main')` is a loose string match that (in principle) could also match a hypothetical branch like `refs/heads/vulnerable/main`. Assessed as low actual risk: the repo's `trigger:` block already permits building on any `v*/main`-shaped branch, and the real trust boundary for a pipeline-as-code repo is push/branch-creation access — anyone with that access could already edit this same YAML file directly to bypass the condition entirely. No further hardening applied, consistent with the pattern the issue asked for.
- Code review: manually reviewed the single-file, 3-line diff; confirmed all three stages use the identical, consistent condition pattern and nothing else in the file was altered.

## Test plan

- [x] `npm ci` / `npm run build` / `npm run compile` succeed
- [x] YAML parses correctly
- [x] `git diff` scoped to only the 3 intended condition changes
- [ ] CI green on this PR (Azure Pipelines build against this branch)

Closes #322


---
_Generated by [Claude Code](https://claude.ai/code/session_01QaCYSPsRUyVBXjapztdKNY)_