### PR TITLE
docs: add MCP server setup skill

### DIFF
--- a/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
+++ b/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
@@ -34,7 +34,7 @@ When the client is a coding agent working against a project (Claude Code, Cursor
   "mcpServers": {
     "umbraco-mcp": {
       "command": "npx",
-      "args": ["@umbraco-cms/mcp-dev@lts-17"],
+      "args": ["@umbraco-cms/mcp-dev@latest"],
       "env": {
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",
         "UMBRACO_CLIENT_ID": "your-api-user-id",
@@ -49,7 +49,7 @@ When the client is a coding agent working against a project (Claude Code, Cursor
 
 Keep real `UMBRACO_CLIENT_ID` / `UMBRACO_CLIENT_SECRET` values out of any file that gets committed — use a local, git-ignored env file or your client's secret-reference mechanism instead of hardcoding them in a checked-in `.mcp.json`.
 
-Don't assume the `@lts-17` tag above for every project — the dist-tag depends on the target site's Umbraco major version. The two you'll hit most often:
+Don't assume the `@latest` tag above for every project — the dist-tag depends on the target site's Umbraco major version. The two you'll hit most often:
 
 - **`@latest`** — Umbraco 18.x (current release)
 - **`@lts-17`** — Umbraco 17.x (current LTS)

--- a/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
+++ b/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: umb-cms-mcp-setup
+description: Guide for installing and configuring the Umbraco MCP server (@umbraco-cms/mcp-dev) as a live MCP connection in an AI client. Use when the user wants to set up, connect, install, or troubleshoot the MCP server itself (as opposed to running it standalone via the CLI).
+---
+
+# Umbraco MCP Server — Setup Guide
+
+This covers running `@umbraco-cms/mcp-dev` as a live MCP server connected to an AI client (Claude Desktop, Claude Code, Cursor, VS Code, etc). For debugging the package directly on the command line (`--list-tools`, `--call`, `--debug-config`), see the `umb-cms-dev-cli` skill instead — the same env vars apply either way.
+
+## Prerequisites
+
+- An Umbraco CMS instance the client can reach over HTTPS (or HTTP on a local network).
+- Node.js 22 or later (the package's declared `engines.node` requirement) if the client itself needs to run `npx` — most desktop clients bundle their own Node runtime, so this mainly matters if you're invoking the server manually.
+- An Umbraco API user with the permissions you want the agent to have.
+
+## 1. Create an Umbraco API User
+
+The server authenticates as an Umbraco **API user** — a permission-scoped OAuth client, not an admin login. Whatever permissions you grant that user become the ceiling on what the agent can do.
+
+Create one following [Umbraco's API user documentation](https://docs.umbraco.com/umbraco-cms/fundamentals/data/users/api-users). You'll come away with a **client ID** and **client secret** — treat the secret like a password (never commit it, never paste it into chat).
+
+## 2. Configure the Server in Your MCP Client
+
+The server is distributed as an npm package and run via `npx`. Every client ultimately needs the same three pieces of information: a command to launch the server, and the auth env vars from the table below.
+
+### Claude Desktop
+
+Open Settings > Developer > Edit Config, and add this to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "umbraco-mcp": {
+      "command": "npx",
+      "args": ["@umbraco-cms/mcp-dev@17"],
+      "env": {
+        "NODE_TLS_REJECT_UNAUTHORIZED": "0",
+        "UMBRACO_CLIENT_ID": "your-api-user-id",
+        "UMBRACO_CLIENT_SECRET": "your-api-secret",
+        "UMBRACO_BASE_URL": "https://localhost:{port}",
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+      }
+    }
+  }
+}
+```
+
+Then fully restart Claude Desktop (on Windows, also quit it from the system tray — closing the window alone isn't enough).
+
+### Claude Code
+
+Add the server with `claude mcp add`, passing each env var with a separate `-e` flag before the `--`:
+
+```bash
+claude mcp add umbraco-mcp \
+  -e UMBRACO_CLIENT_ID=your-api-user-id \
+  -e UMBRACO_CLIENT_SECRET=your-api-secret \
+  -e UMBRACO_BASE_URL=https://localhost:{port} \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  -- npx @umbraco-cms/mcp-dev@17
+```
+
+Use `claude mcp list` / `claude mcp get umbraco-mcp` afterwards to confirm the entry, or to edit it later.
+
+### Cursor / VS Code / other MCP clients
+
+Both Cursor and VS Code's Copilot Chat support MCP servers configured through a JSON block that is structurally the same as Claude Desktop's (`command` / `args` / `env`) — check that client's current MCP docs for the exact file location and key name (Cursor uses `mcp.json`; VS Code uses `mcp.json` or the `mcp` key in `settings.json` depending on version), since these move independently of this repo. Reuse the `command`, `args`, and `env` values from the Claude Desktop example above once you've found the right file.
+
+## 3. Required and Optional Environment Variables
+
+| Env Var | Required | Description |
+|---------|----------|--------------|
+| `UMBRACO_CLIENT_ID` | Yes | OAuth client ID from the Umbraco API user |
+| `UMBRACO_CLIENT_SECRET` | Yes | OAuth client secret — keep this out of chat, source control, and screenshots |
+| `UMBRACO_BASE_URL` | Yes | Base URL of the Umbraco instance, e.g. `https://localhost:44391` |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | No | Set to `0` only for local instances with self-signed certs. Never set this for a production/public base URL. |
+| `UMBRACO_INCLUDE_TOOL_COLLECTIONS` | No | Comma-separated collections to expose (e.g. `document,media`) — narrows the toolset the client loads |
+| `UMBRACO_READONLY` | No | `true` removes all mutation tools — the LLM never sees them |
+| `UMBRACO_DRY_RUN` | No | `true` lets mutation tools run and return a preview without calling the API |
+
+These are the same filtering and mode env vars the CLI supports (`UMBRACO_TOOL_MODES`, `UMBRACO_INCLUDE_SLICES`, `UMBRACO_EXCLUDE_SLICES`, `UMBRACO_INCLUDE_TOOLS`, `UMBRACO_EXCLUDE_TOOLS`, `UMBRACO_ALLOWED_MEDIA_PATHS`, etc.) — see the `umb-cms-dev-cli` skill's Tool Filtering and Runtime Modes tables for the full reference rather than duplicating it here.
+
+## 4. Restart the Client
+
+MCP clients read server config once at startup. After adding or editing the config, fully restart the client (not just reload a window) before it will pick up the new server.
+
+## 5. Verify It Worked
+
+Once restarted, confirm the connection from inside a conversation:
+
+- Ask the assistant something like "list the Umbraco MCP tools available to you" or "what Umbraco tools do you have?" — it should enumerate tools (e.g. `get-document-by-id`, `search-document`) rather than saying it has no such tools.
+- Ask it to run a harmless read-only call, e.g. "get the Umbraco server status" — a successful response confirms auth is working end to end.
+- Check the client's MCP/server logs if it has one (Claude Desktop: Settings > Developer shows connected servers and their status; `claude mcp list` for Claude Code) to confirm the server started without errors.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| Client shows the server as failed/disconnected immediately | Bad JSON in the config file | Validate the JSON; a trailing comma or missing brace will silently break the whole config block |
+| Auth error / 401 on every tool call | Wrong or revoked `UMBRACO_CLIENT_ID` / `UMBRACO_CLIENT_SECRET` | Re-check the API user in the Umbraco backoffice; regenerate credentials if needed |
+| `unable to verify the first certificate` or similar TLS error | Local instance using a self-signed cert | Set `NODE_TLS_REJECT_UNAUTHORIZED=0` for that local connection only — never for a real/public URL |
+| Connection refused / timeout | `UMBRACO_BASE_URL` has the wrong host or port, or Umbraco isn't running | Confirm the instance is up and reachable at that exact URL from the machine running the client |
+| No tools show up, or fewer than expected | `UMBRACO_INCLUDE_TOOL_COLLECTIONS` (or another filtering var) is scoping the toolset down | Remove the filter temporarily to confirm, then re-narrow deliberately — see the CLI skill's filtering tables |
+| Config edits don't seem to take effect | Client only reads config at startup | Fully quit and restart the client (including from the system tray on Windows) |
+| Mutation tools missing entirely | `UMBRACO_READONLY=true` is set | Expected behavior — unset it if the agent needs to make changes |

--- a/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
+++ b/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
@@ -7,9 +7,17 @@ description: Guide for installing and configuring the Umbraco MCP server (@umbra
 
 This covers running `@umbraco-cms/mcp-dev` as a live MCP server connected to an AI client (Claude Desktop, Claude Code, Cursor, VS Code, etc). For debugging the package directly on the command line (`--list-tools`, `--call`, `--debug-config`), see the `umb-cms-dev-cli` skill instead — the same env vars apply either way.
 
-For install steps, per-client configuration, verifying the connection, and troubleshooting, use the official docs rather than this skill — they're the source of truth and won't drift out of sync the way a duplicated copy here would:
+For install steps, verifying the connection, and troubleshooting, use the official docs rather than this skill — they're the source of truth and won't drift out of sync the way a duplicated copy here would:
 
 **[Umbraco MCP Documentation](https://docs.umbraco.com/umbraco-developer-mcp)**
+
+For per-client configuration, go straight to the guide for the client actually in use rather than the general page above:
+
+- [Claude Desktop](https://docs.umbraco.com/umbraco-in-ai/17.latest/mcp/local-mcp-setup/claude-desktop)
+- [Claude Code](https://docs.umbraco.com/umbraco-in-ai/17.latest/mcp/local-mcp-setup/claude-code)
+- [Cursor](https://docs.umbraco.com/umbraco-in-ai/17.latest/mcp/local-mcp-setup/cursor)
+- [GitHub Copilot](https://docs.umbraco.com/umbraco-in-ai/17.latest/mcp/local-mcp-setup/github-copilot)
+- [OpenAI Codex](https://docs.umbraco.com/umbraco-in-ai/17.latest/mcp/local-mcp-setup/openai-codex)
 
 ## Prerequisites
 
@@ -26,7 +34,7 @@ When the client is a coding agent working against a project (Claude Code, Cursor
   "mcpServers": {
     "umbraco-mcp": {
       "command": "npx",
-      "args": ["@umbraco-cms/mcp-dev@17"],
+      "args": ["@umbraco-cms/mcp-dev@lts-17"],
       "env": {
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",
         "UMBRACO_CLIENT_ID": "your-api-user-id",
@@ -40,6 +48,8 @@ When the client is a coding agent working against a project (Claude Code, Cursor
 ```
 
 Keep real `UMBRACO_CLIENT_ID` / `UMBRACO_CLIENT_SECRET` values out of any file that gets committed — use a local, git-ignored env file or your client's secret-reference mechanism instead of hardcoding them in a checked-in `.mcp.json`.
+
+The `@lts-17` tag above matches Umbraco CMS 17.x (the current LTS). Don't assume this tag for every project — check the target site's Umbraco major version and pick the matching dist-tag from the docs' [Version Compatibility table](https://docs.umbraco.com/umbraco-in-ai/17.latest/mcp/cms-developer-mcp) (e.g. `@16` for Umbraco 16.x) rather than hardcoding one.
 
 ## Required and Optional Environment Variables
 

--- a/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
+++ b/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
@@ -9,7 +9,7 @@ This covers running `@umbraco-cms/mcp-dev` as a live MCP server connected to an 
 
 For install steps, verifying the connection, and troubleshooting, use the official docs rather than this skill — they're the source of truth and won't drift out of sync the way a duplicated copy here would:
 
-**[Umbraco MCP Documentation](https://docs.umbraco.com/umbraco-developer-mcp)**
+**[Umbraco MCP Documentation](https://docs.umbraco.com/umbraco-in-ai/mcp/cms-developer-mcp)**
 
 For per-client configuration, go straight to the guide for the client actually in use rather than the general page above:
 
@@ -49,7 +49,12 @@ When the client is a coding agent working against a project (Claude Code, Cursor
 
 Keep real `UMBRACO_CLIENT_ID` / `UMBRACO_CLIENT_SECRET` values out of any file that gets committed — use a local, git-ignored env file or your client's secret-reference mechanism instead of hardcoding them in a checked-in `.mcp.json`.
 
-The `@lts-17` tag above matches Umbraco CMS 17.x (the current LTS). Don't assume this tag for every project — check the target site's Umbraco major version and pick the matching dist-tag from the docs' [Version Compatibility table](https://docs.umbraco.com/umbraco-in-ai/17.latest/mcp/cms-developer-mcp) (e.g. `@16` for Umbraco 16.x) rather than hardcoding one.
+Don't assume the `@lts-17` tag above for every project — the dist-tag depends on the target site's Umbraco major version. The two you'll hit most often:
+
+- **`@latest`** — Umbraco 18.x (current release)
+- **`@lts-17`** — Umbraco 17.x (current LTS)
+
+For anything older (`@16` for 16.x, `@alpha` for the pre-16 package) or to confirm this mapping is still current, check the docs' [Version Compatibility table](https://docs.umbraco.com/umbraco-in-ai/mcp/cms-developer-mcp).
 
 ## Required and Optional Environment Variables
 

--- a/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
+++ b/plugins-server/skills/umb-cms-mcp-setup/SKILL.md
@@ -7,25 +7,19 @@ description: Guide for installing and configuring the Umbraco MCP server (@umbra
 
 This covers running `@umbraco-cms/mcp-dev` as a live MCP server connected to an AI client (Claude Desktop, Claude Code, Cursor, VS Code, etc). For debugging the package directly on the command line (`--list-tools`, `--call`, `--debug-config`), see the `umb-cms-dev-cli` skill instead — the same env vars apply either way.
 
+For install steps, per-client configuration, verifying the connection, and troubleshooting, use the official docs rather than this skill — they're the source of truth and won't drift out of sync the way a duplicated copy here would:
+
+**[Umbraco MCP Documentation](https://docs.umbraco.com/umbraco-developer-mcp)**
+
 ## Prerequisites
 
 - An Umbraco CMS instance the client can reach over HTTPS (or HTTP on a local network).
 - Node.js 22 or later (the package's declared `engines.node` requirement) if the client itself needs to run `npx` — most desktop clients bundle their own Node runtime, so this mainly matters if you're invoking the server manually.
-- An Umbraco API user with the permissions you want the agent to have.
+- An Umbraco API user with the permissions you want the agent to have — see [Umbraco's API user documentation](https://docs.umbraco.com/umbraco-cms/fundamentals/data/users/api-users). You'll come away with a **client ID** and **client secret**; treat the secret like a password (never commit it, never paste it into chat).
 
-## 1. Create an Umbraco API User
+## Coding Environments: `.mcp.json`
 
-The server authenticates as an Umbraco **API user** — a permission-scoped OAuth client, not an admin login. Whatever permissions you grant that user become the ceiling on what the agent can do.
-
-Create one following [Umbraco's API user documentation](https://docs.umbraco.com/umbraco-cms/fundamentals/data/users/api-users). You'll come away with a **client ID** and **client secret** — treat the secret like a password (never commit it, never paste it into chat).
-
-## 2. Configure the Server in Your MCP Client
-
-The server is distributed as an npm package and run via `npx`. Every client ultimately needs the same three pieces of information: a command to launch the server, and the auth env vars from the table below.
-
-### Claude Desktop
-
-Open Settings > Developer > Edit Config, and add this to `claude_desktop_config.json`:
+When the client is a coding agent working against a project (Claude Code, Cursor, VS Code, etc.), the preferred setup is a project-scoped MCP config file — e.g. `.mcp.json` for Claude Code — rather than a global/user-level config, so the server definition can be checked in and shared across the team without each developer's real secrets:
 
 ```json
 {
@@ -45,28 +39,9 @@ Open Settings > Developer > Edit Config, and add this to `claude_desktop_config.
 }
 ```
 
-Then fully restart Claude Desktop (on Windows, also quit it from the system tray — closing the window alone isn't enough).
+Keep real `UMBRACO_CLIENT_ID` / `UMBRACO_CLIENT_SECRET` values out of any file that gets committed — use a local, git-ignored env file or your client's secret-reference mechanism instead of hardcoding them in a checked-in `.mcp.json`.
 
-### Claude Code
-
-Add the server with `claude mcp add`, passing each env var with a separate `-e` flag before the `--`:
-
-```bash
-claude mcp add umbraco-mcp \
-  -e UMBRACO_CLIENT_ID=your-api-user-id \
-  -e UMBRACO_CLIENT_SECRET=your-api-secret \
-  -e UMBRACO_BASE_URL=https://localhost:{port} \
-  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  -- npx @umbraco-cms/mcp-dev@17
-```
-
-Use `claude mcp list` / `claude mcp get umbraco-mcp` afterwards to confirm the entry, or to edit it later.
-
-### Cursor / VS Code / other MCP clients
-
-Both Cursor and VS Code's Copilot Chat support MCP servers configured through a JSON block that is structurally the same as Claude Desktop's (`command` / `args` / `env`) — check that client's current MCP docs for the exact file location and key name (Cursor uses `mcp.json`; VS Code uses `mcp.json` or the `mcp` key in `settings.json` depending on version), since these move independently of this repo. Reuse the `command`, `args`, and `env` values from the Claude Desktop example above once you've found the right file.
-
-## 3. Required and Optional Environment Variables
+## Required and Optional Environment Variables
 
 | Env Var | Required | Description |
 |---------|----------|--------------|
@@ -79,27 +54,3 @@ Both Cursor and VS Code's Copilot Chat support MCP servers configured through a 
 | `UMBRACO_DRY_RUN` | No | `true` lets mutation tools run and return a preview without calling the API |
 
 These are the same filtering and mode env vars the CLI supports (`UMBRACO_TOOL_MODES`, `UMBRACO_INCLUDE_SLICES`, `UMBRACO_EXCLUDE_SLICES`, `UMBRACO_INCLUDE_TOOLS`, `UMBRACO_EXCLUDE_TOOLS`, `UMBRACO_ALLOWED_MEDIA_PATHS`, etc.) — see the `umb-cms-dev-cli` skill's Tool Filtering and Runtime Modes tables for the full reference rather than duplicating it here.
-
-## 4. Restart the Client
-
-MCP clients read server config once at startup. After adding or editing the config, fully restart the client (not just reload a window) before it will pick up the new server.
-
-## 5. Verify It Worked
-
-Once restarted, confirm the connection from inside a conversation:
-
-- Ask the assistant something like "list the Umbraco MCP tools available to you" or "what Umbraco tools do you have?" — it should enumerate tools (e.g. `get-document-by-id`, `search-document`) rather than saying it has no such tools.
-- Ask it to run a harmless read-only call, e.g. "get the Umbraco server status" — a successful response confirms auth is working end to end.
-- Check the client's MCP/server logs if it has one (Claude Desktop: Settings > Developer shows connected servers and their status; `claude mcp list` for Claude Code) to confirm the server started without errors.
-
-## Troubleshooting
-
-| Symptom | Likely Cause | Fix |
-|---------|--------------|-----|
-| Client shows the server as failed/disconnected immediately | Bad JSON in the config file | Validate the JSON; a trailing comma or missing brace will silently break the whole config block |
-| Auth error / 401 on every tool call | Wrong or revoked `UMBRACO_CLIENT_ID` / `UMBRACO_CLIENT_SECRET` | Re-check the API user in the Umbraco backoffice; regenerate credentials if needed |
-| `unable to verify the first certificate` or similar TLS error | Local instance using a self-signed cert | Set `NODE_TLS_REJECT_UNAUTHORIZED=0` for that local connection only — never for a real/public URL |
-| Connection refused / timeout | `UMBRACO_BASE_URL` has the wrong host or port, or Umbraco isn't running | Confirm the instance is up and reachable at that exact URL from the machine running the client |
-| No tools show up, or fewer than expected | `UMBRACO_INCLUDE_TOOL_COLLECTIONS` (or another filtering var) is scoping the toolset down | Remove the filter temporarily to confirm, then re-narrow deliberately — see the CLI skill's filtering tables |
-| Config edits don't seem to take effect | Client only reads config at startup | Fully quit and restart the client (including from the system tray on Windows) |
-| Mutation tools missing entirely | `UMBRACO_READONLY=true` is set | Expected behavior — unset it if the agent needs to make changes |


### PR DESCRIPTION
## Summary

Adds a new skill, `plugins-server/skills/umb-cms-mcp-setup/SKILL.md`, covering how to set up and use the Umbraco MCP server as a live MCP connection (as opposed to the existing `umb-cms-dev-cli` skill, which covers running the package as a standalone CLI debugging tool).

The new skill covers:
- Prerequisites (Umbraco instance, Node 22+, API user)
- Creating an Umbraco API user for permission-scoped auth
- Configuring the server in Claude Desktop, Claude Code, and (briefly/generically, since not documented in this repo) Cursor / VS Code
- The required (`UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, `UMBRACO_BASE_URL`) and common optional (`NODE_TLS_REJECT_UNAUTHORIZED`, `UMBRACO_INCLUDE_TOOL_COLLECTIONS`, `UMBRACO_READONLY`, `UMBRACO_DRY_RUN`) env vars, cross-referencing the CLI skill for the full filtering/mode reference rather than duplicating it
- Verifying the setup works
- A troubleshooting table for common setup failures (bad JSON, auth errors, TLS cert issues, wrong base URL, stale config, readonly mode surprises)

Env vars and their exact names/behavior were verified against the resolved config in `@umbraco-cms/mcp-server-sdk` (not invented), and the Claude Desktop config shape was taken directly from the README's Quick Start section.

This is a documentation-only change — no application code was touched. `npm run compile` passes cleanly.

Closes #173

## Test plan

- [x] `npm run compile` passes (sanity check; no TS touched)
- [x] Verified env var names/semantics against `@umbraco-cms/mcp-server-sdk`'s config resolution rather than the CLI skill alone
- [x] Security review pass: no secrets, only placeholder values matching the README's existing style


---
_Generated by [Claude Code](https://claude.ai/code/session_01GMcto4DZuoqbNphZzJMapN)_