### PR TITLE
fix: derive isStable from channel, not dist-tag, on v17 LTS line

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -129,7 +129,7 @@ stages:
             fi
 
             # Set output variable for MCP Registry stage
-            if [ "$tag" = "latest" ]; then
+            if [ "$channel" = "latest" ]; then
               echo "##vso[task.setvariable variable=isStable;isOutput=true]true"
             else
               echo "##vso[task.setvariable variable=isStable;isOutput=true]false"


### PR DESCRIPTION
## Summary

Fixes a bug in the `Deploy_Npm` stage's "Push to npm with dynamic tagging" script in `build/azure-pipelines.yml` on the v17 LTS line.

On `v17/main`, the npm dist-tag is always mapped to `lts-17` or `lts-17-<channel>` (never the literal string `"latest"`), because the LTS line scopes its dist-tags away from the default `latest`/`alpha`/`beta`/`rc` channel names. The final `isStable` output-variable check compared against `$tag`, so it was structurally always false on `v17/main` — even for a genuinely stable patch release.

This had two downstream effects:
- **B1**: `Create_GitHub_Release` always added `--prerelease`, mislabeling stable v17.x releases as GitHub prereleases.
- **B3**: `Deploy_MCP_Registry`'s job-level condition (`eq(variables['isStableRelease'], 'true')`) was always false on `v17/main`, so the MCP Registry publish was always skipped for that line — regardless of the stage-level branch condition (already broadened to include `v17/main` in #324 / commit `03317af2`).

## Fix

One-line change: the `isStable` check now keys off `$channel` (the pre-LTS-mapping value, computed directly from the version string as `alpha`/`beta`/`rc`/`latest`) instead of `$tag` (the LTS-line-specific dist-tag name). `channel` is what actually reflects whether a release is stable, independent of which dist-tag naming scheme applies to the branch.

```diff
 # Set output variable for MCP Registry stage
-if [ "$tag" = "latest" ]; then
+if [ "$channel" = "latest" ]; then
   echo "##vso[task.setvariable variable=isStable;isOutput=true]true"
 else
   echo "##vso[task.setvariable variable=isStable;isOutput=true]false"
 fi
```

Nothing else in the file was touched. The mainline `dev`/`main` copy of this pipeline file does not have the v17 LTS dist-tag branching logic at all, so this bug does not exist there and was left untouched.

Closes #344

## Test plan

- [x] `npm run compile` — sanity check (safe to run anytime per repo conventions). Pre-existing `tsconfig.json` `baseUrl` deprecation warning is unrelated and present identically before/after this change.
- This is a CI-pipeline-YAML-only change (Azure Pipelines script), with no TypeScript or test-exercised code touched — there is nothing in the diff that any Jest test could exercise, so the test gate is compile-only by design. Booting a full Umbraco instance for a YAML-only change would be wasted effort.
- `/security-review` run: no findings (the diff only swaps which pre-existing local shell variable is compared in an `if [ ... = "latest" ]` check; no new input, injection, auth, or secrets surface).
- `/code-review low`-equivalent manual pass run: no findings (style/quoting consistent with surrounding script, `channel` already defined before use, no other stale `$tag` references needed updating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018GQz8FiEoVCGbCZMmV7BfP)_