### PR TITLE
Release 18.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.0-rc",
+  "version": "18.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "18.1.0-rc",
+      "version": "18.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.0-rc",
+  "version": "18.1.0",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "18.1.0-rc",
+  "version": "18.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "18.1.0-rc",
+      "version": "18.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumps the version to `18.1.0` (promoting the already-released `18.1.0-rc` to final).

- `package.json` / `package-lock.json` / `server.json` version fields bumped from `18.1.0-rc` to `18.1.0`.

Closes #382

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFwFB6iH1PNwPw2mq816XR)_