### PR TITLE
Release 17.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.6.0-rc",
+    "version": "17.6.0",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.6.0-rc",
+      "version": "17.6.0",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.0-rc",
+  "version": "17.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.6.0-rc",
+      "version": "17.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.0-rc",
+  "version": "17.6.0",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.6.0-rc",
+  "version": "17.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.6.0-rc",
+      "version": "17.6.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Finalizes the `17.6.0-rc` release candidate of the v17 (LTS) line as stable `17.6.0`. `v17/dev` and `v17/main` carry no changes beyond the rc, so this is a version-only bump.

Bumps the version to `17.6.0` across `package.json`, `package-lock.json`, `server.json`, and `.claude-plugin/marketplace.json`.

Closes #383

🤖 Generated by the auto-release-loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWvnACZzihYNQz5eojaQB)_