### PR TITLE
Merge v17/main into v17/dev (sync release 17.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.6.0-rc",
+    "version": "17.6.0",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.6.0-rc",
+      "version": "17.6.0",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.0-rc",
+  "version": "17.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.6.0-rc",
+      "version": "17.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.0-rc",
+  "version": "17.6.0",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.6.0-rc",
+  "version": "17.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.6.0-rc",
+      "version": "17.6.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Syncs `v17/dev` with `v17/main` after the 17.6.0 release (PR #385, tag `v17.6.0`) so the version bump lands back on the integration branch.

Clean fast-forward — no divergent changes on `v17/dev`.

Related to #383 (release 17.6.0).

🤖 Generated by the auto-release-loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PWvnACZzihYNQz5eojaQB)_