### PR TITLE
chore: merge main into dev (release 18.1.1 sync-back)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,8 +123,22 @@ jobs:
           cat test-failures.log >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "No failure log found"
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+        timeout-minutes: 5
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+        timeout-minutes: 5
 
       - name: Run Playwright E2E tests
         run: npm run test:e2e

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "18.1.0",
+      "version": "18.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "18.1.0",
+  "version": "18.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "18.1.0",
+      "version": "18.1.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Syncs `dev` with `main` after the 18.1.1 release (PR #397), bringing in the version bump and the Playwright CI reliability fix that was pushed directly to the release branch.

Closes #396 (part of the release 18.1.1 sync-back)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TY9EQ2vXUg432aJw2jZ1S9)_