### PR TITLE
Wire up OTel tracing in the hosted Worker and fix its stale version

### DIFF
--- a/src/cloudflare-workers.d.ts
+++ b/src/cloudflare-workers.d.ts
@@ -4,12 +4,12 @@
 // package isn't a dependency here because it redefines DOM-ish globals
 // (Request/Response/fetch/...) that collide with this repo's Node-targeted
 // code, which also compiles under this same tsconfig.
+//
+// The `import(...)` type query (rather than a top-level `import`) is
+// deliberate: a top-level import/export would make TypeScript treat this
+// file as a module, and `declare module "cloudflare:workers"` in a module
+// file only *augments* an existing module rather than declaring a new
+// ambient one — silently leaving the import in worker.ts unresolved.
 declare module "cloudflare:workers" {
-  interface CloudflareTracingSpan {
-    setAttribute(key: string, value?: boolean | number | string): void;
-  }
-
-  export const tracing: {
-    enterSpan<T>(name: string, callback: (span: CloudflareTracingSpan) => T): T;
-  };
+  export const tracing: import("@umbraco-cms/mcp-hosted").CloudflareTracing;
 }

--- a/src/cloudflare-workers.d.ts
+++ b/src/cloudflare-workers.d.ts
@@ -1,0 +1,15 @@
+// Minimal ambient typing for the `cloudflare:workers` virtual module (resolved
+// by wrangler at build time, not present in node_modules). Only covers the
+// `tracing` export worker.ts uses — the full `@cloudflare/workers-types`
+// package isn't a dependency here because it redefines DOM-ish globals
+// (Request/Response/fetch/...) that collide with this repo's Node-targeted
+// code, which also compiles under this same tsconfig.
+declare module "cloudflare:workers" {
+  interface CloudflareTracingSpan {
+    setAttribute(key: string, value?: boolean | number | string): void;
+  }
+
+  export const tracing: {
+    enterSpan<T>(name: string, callback: (span: CloudflareTracingSpan) => T): T;
+  };
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,6 +19,7 @@ import {
   createSiteRoutingApiHandler,
   getServerOptions,
   type HostedMcpEnv,
+  type HostedMcpServerOptions,
   type AuthProps,
 } from "@umbraco-cms/mcp-hosted";
 import { umbracoCloudSiteRouting } from "@umbraco-cms/mcp-hosted/cloud";
@@ -34,7 +35,7 @@ import packageJson from "../package.json" with { type: "json" };
 // Server Configuration
 // ============================================================================
 
-const options = {
+const options: HostedMcpServerOptions = {
   name: "umbraco-cms-mcp",
   version: packageJson.version,
   // Hosted counterpart of the stdio entry point's version check: when set,
@@ -45,7 +46,6 @@ const options = {
   // createPerRequestServer has no pre-execution-hook equivalent, so a
   // mismatch here is warn-only.
   expectedUmbracoMajor: UMBRACO_TARGET_MAJOR,
-  telemetry: { tracing },
   collections,
   modeRegistry: allModes,
   allModeNames,
@@ -56,7 +56,10 @@ const options = {
   siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-dev-mcp-hosted" }),
 };
 
-const serverOptions = getServerOptions(options);
+// `telemetry` lives on `CreateServerOptions`, not `HostedMcpServerOptions` —
+// getServerOptions() builds a fresh CreateServerOptions object and would
+// silently drop it if it were set on `options` above instead.
+const serverOptions = { ...getServerOptions(options), telemetry: { tracing } };
 
 // ============================================================================
 // McpAgent Durable Object

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,6 +6,7 @@
  */
 
 // Wrangler virtual modules
+import { tracing } from "cloudflare:workers";
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OAuthProvider from "@cloudflare/workers-oauth-provider";
@@ -27,6 +28,7 @@ import { collections, allModes, allModeNames, allSliceNames } from "./collection
 import { UMBRACO_TARGET_MAJOR } from "./config/umbraco-target.generated.js";
 import { UmbracoManagementClient } from "./umbraco-api/umbraco-management-client.js";
 import { setStreamingAuthContext } from "./umbraco-api/tools/media/post/helpers/streaming-upload.js";
+import packageJson from "../package.json" with { type: "json" };
 
 // ============================================================================
 // Server Configuration
@@ -34,7 +36,7 @@ import { setStreamingAuthContext } from "./umbraco-api/tools/media/post/helpers/
 
 const options = {
   name: "umbraco-cms-mcp",
-  version: "17.1.2",
+  version: packageJson.version,
   // Hosted counterpart of the stdio entry point's version check: when set,
   // createPerRequestServer verifies the connected Umbraco's major on every
   // request and folds a mismatch warning into that request's `instructions`.
@@ -43,6 +45,7 @@ const options = {
   // createPerRequestServer has no pre-execution-hook equivalent, so a
   // mismatch here is warn-only.
   expectedUmbracoMajor: UMBRACO_TARGET_MAJOR,
+  telemetry: { tracing },
   collections,
   modeRegistry: allModes,
   allModeNames,


### PR DESCRIPTION
## Summary

- `src/worker.ts` never opted into `@umbraco-cms/mcp-hosted`'s OpenTelemetry instrumentation, even though the dependency (`^1.0.0-beta.36`, already in `package.json`) supports it — `tracing` has to be handed in from the Worker since `cloudflare:workers` only resolves inside the Workers runtime. Added `import { tracing } from "cloudflare:workers"` and `telemetry: { tracing }` in the server options.
- Replaced the hardcoded `version: "17.1.2"` with `packageJson.version`, matching the pattern already used in the stdio entry point (`src/index.ts`). This value is reported to MCP clients on `initialize` and now also lands in the `umbraco.mcp.server.version` span attribute once tracing is live.
- `cloudflare:workers` is a wrangler virtual module with no npm package backing it here, so `tsc` had no type for the import. Adding the full `@cloudflare/workers-types` package (as this repo's sibling `template/` project in `Umbraco-MCP-Base` does) turned out to redefine globals (`Response`/`Request`/etc.) that collide with this repo's Node-targeted code under the same `tsconfig.json` — that broke compilation elsewhere. Instead added `src/cloudflare-workers.d.ts`, a narrow ambient declaration covering only the `tracing` export this file uses.

No dependency version changes, no config changes.

## Testing

- `npm run compile` — clean.
- No existing test covers `src/worker.ts` (confirmed via `npx jest --findRelatedTests`), and this change isn't unit-testable in isolation — tracing spans are only observable by deploying and calling a tool against a live Worker (see the issue's verification steps). Manually reviewed the diff against `@umbraco-cms/mcp-hosted`'s `telemetry` option types to confirm the shape matches.
- Along the way, noticed `scripts/test-changed.mjs`'s pathspec (`src/**/*.ts`) doesn't match files directly under `src/` (only in subdirectories) under git's default non-glob pathspec matching — that's how this diff evaded `npm run test:changed` entirely. Out of scope for this PR; flagging as a possible follow-up.

Closes #399


---
_Generated by [Claude Code](https://claude.ai/code/session_011gtP8F7R3tMtMFugzWn8jL)_