### PR TITLE
Wire up OTel tracing in the hosted Worker and fix its stale version (v17 line)

### DIFF
--- a/src/cloudflare-workers.d.ts
+++ b/src/cloudflare-workers.d.ts
@@ -1,0 +1,15 @@
+// Minimal ambient typing for the `cloudflare:workers` virtual module (resolved
+// by wrangler at build time, not present in node_modules). Only covers the
+// `tracing` export worker.ts uses — the full `@cloudflare/workers-types`
+// package isn't a dependency here because it redefines DOM-ish globals
+// (Request/Response/fetch/...) that collide with this repo's Node-targeted
+// code, which also compiles under this same tsconfig.
+//
+// The `import(...)` type query (rather than a top-level `import`) is
+// deliberate: a top-level import/export would make TypeScript treat this
+// file as a module, and `declare module "cloudflare:workers"` in a module
+// file only *augments* an existing module rather than declaring a new
+// ambient one — silently leaving the import in worker.ts unresolved.
+declare module "cloudflare:workers" {
+  export const tracing: import("@umbraco-cms/mcp-hosted").CloudflareTracing;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,6 +6,7 @@
  */
 
 // Wrangler virtual modules
+import { tracing } from "cloudflare:workers";
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OAuthProvider from "@cloudflare/workers-oauth-provider";
@@ -18,6 +19,7 @@ import {
   createSiteRoutingApiHandler,
   getServerOptions,
   type HostedMcpEnv,
+  type HostedMcpServerOptions,
   type AuthProps,
 } from "@umbraco-cms/mcp-hosted";
 import { umbracoCloudSiteRouting } from "@umbraco-cms/mcp-hosted/cloud";
@@ -27,14 +29,15 @@ import { collections, allModes, allModeNames, allSliceNames } from "./collection
 import { UMBRACO_TARGET_MAJOR } from "./config/umbraco-target.generated.js";
 import { UmbracoManagementClient } from "./umbraco-api/umbraco-management-client.js";
 import { setStreamingAuthContext } from "./umbraco-api/tools/media/post/helpers/streaming-upload.js";
+import packageJson from "../package.json" with { type: "json" };
 
 // ============================================================================
 // Server Configuration
 // ============================================================================
 
-const options = {
+const options: HostedMcpServerOptions = {
   name: "umbraco-cms-mcp",
-  version: "17.1.2",
+  version: packageJson.version,
   // Hosted counterpart of the stdio entry point's version check: when set,
   // createPerRequestServer verifies the connected Umbraco's major on every
   // request and folds a mismatch warning into that request's `instructions`.
@@ -53,7 +56,10 @@ const options = {
   siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-dev-mcp-hosted" }),
 };
 
-const serverOptions = getServerOptions(options);
+// `telemetry` lives on `CreateServerOptions`, not `HostedMcpServerOptions` —
+// getServerOptions() builds a fresh CreateServerOptions object and would
+// silently drop it if it were set on `options` above instead.
+const serverOptions = { ...getServerOptions(options), telemetry: { tracing } };
 
 // ============================================================================
 // McpAgent Durable Object


### PR DESCRIPTION
## Summary

This is the v17-line port of #400, which fixed the identical bug on the `dev`/`main` (v18) line for #399.

- `src/worker.ts` never opted into `@umbraco-cms/mcp-hosted`'s OpenTelemetry instrumentation, even though the dependency (`^1.0.0-beta.36`, already in `package.json`) supports it — `tracing` has to be handed in from the Worker since `cloudflare:workers` only resolves inside the Workers runtime. Added `import { tracing } from "cloudflare:workers"` and `telemetry: { tracing }`.
  - `telemetry` lives on `CreateServerOptions` (the object `getServerOptions()` returns), not on `HostedMcpServerOptions` (the object passed into it) — so `telemetry: { tracing }` is spread onto `serverOptions` after calling `getServerOptions(options)`, not placed inside `options`. Putting it on `options` compiles fine but `getServerOptions()` silently drops it, reproducing the original bug (this was the exact mistake called out on #399's review). `options` is now typed as `HostedMcpServerOptions` so a future regression of that mistake fails to typecheck.
- Replaced the hardcoded `version: "17.1.2"` with `packageJson.version`, matching the pattern already used in the stdio entry point (`src/index.ts`). This value is reported to MCP clients on `initialize` and now also lands in the `umbraco.mcp.server.version` span attribute once tracing is live.
- `cloudflare:workers` is a wrangler virtual module with no npm package backing it here, so `tsc` had no type for the import. Rather than add the full `@cloudflare/workers-types` package (which redefines globals like `Response`/`Request` that collide with this repo's Node-targeted code under the same `tsconfig.json`), added `src/cloudflare-workers.d.ts`, a narrow ambient declaration covering only the `tracing` export this file uses.

No dependency version changes, no config changes.

## Testing

- `npm run compile` — clean.
- `npm run build` — clean (bundles the stdio entry points; the Worker itself bundles via wrangler, verified separately with `npx wrangler deploy --dry-run`, which also succeeded).
- No existing test covers `src/worker.ts`, and this change isn't unit-testable in isolation — tracing spans are only observable by deploying and calling a tool against a live Worker. Matches the testing approach taken on #400.

Closes #401


---
_Generated by [Claude Code](https://claude.ai/code/session_018DRyTRmFJ3wMieUJBckH94)_