### PR TITLE
fix(ci): disable MCP registry publish stage

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -170,31 +170,34 @@ stages:
           env:
             GH_TOKEN: $(MCP_REGISTRY_GITHUB_TOKEN)
 
-- stage: Deploy_MCP_Registry
-  displayName: MCP Registry release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-  dependsOn:
-    - Deploy_Npm
-  jobs:
-    - job: Publish_MCP
-      displayName: Push to MCP Registry
-      variables:
-        isStableRelease: $[ stageDependencies.Deploy_Npm.Publish.outputs['npmPublish.isStable'] ]
-      condition: eq(variables['isStableRelease'], 'true')
-      steps:
-        - checkout: self
-
-        - script: |
-            # Install mcp-publisher (download and extract pre-built binary)
-            curl -L -o mcp-publisher.tar.gz https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz
-            tar -xzf mcp-publisher.tar.gz
-            chmod +x mcp-publisher
-          displayName: 'Install mcp-publisher'
-
-        - script: |
-            ./mcp-publisher login github --token=$(MCP_REGISTRY_GITHUB_TOKEN)
-          displayName: 'Authenticate with MCP Registry'
-
-        - script: |
-            ./mcp-publisher publish
-          displayName: 'Publish to MCP Registry'
+# MCP Registry publishing is temporarily disabled — the registry auth token has
+# expired/is invalid, and publish steps were failing. Re-enable once a valid
+# MCP_REGISTRY_GITHUB_TOKEN is in place.
+# - stage: Deploy_MCP_Registry
+#   displayName: MCP Registry release
+#   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+#   dependsOn:
+#     - Deploy_Npm
+#   jobs:
+#     - job: Publish_MCP
+#       displayName: Push to MCP Registry
+#       variables:
+#         isStableRelease: $[ stageDependencies.Deploy_Npm.Publish.outputs['npmPublish.isStable'] ]
+#       condition: eq(variables['isStableRelease'], 'true')
+#       steps:
+#         - checkout: self
+#
+#         - script: |
+#             # Install mcp-publisher (download and extract pre-built binary)
+#             curl -L -o mcp-publisher.tar.gz https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz
+#             tar -xzf mcp-publisher.tar.gz
+#             chmod +x mcp-publisher
+#           displayName: 'Install mcp-publisher'
+#
+#         - script: |
+#             ./mcp-publisher login github --token=$(MCP_REGISTRY_GITHUB_TOKEN)
+#           displayName: 'Authenticate with MCP Registry'
+#
+#         - script: |
+#             ./mcp-publisher publish
+#           displayName: 'Publish to MCP Registry'


### PR DESCRIPTION
## Summary
- The MCP registry publish step (`mcp-publisher publish`) fails because the `MCP_REGISTRY_GITHUB_TOKEN` used to authenticate has expired.
- Comments out the `Deploy_MCP_Registry` stage in `build/azure-pipelines.yml` so main-branch release builds stop failing on this step.
- Re-enable once a valid registry token is issued.

## Test plan
- [ ] N/A — pipeline config only, no app code changes