### PR TITLE
ci: cache Playwright browsers and bound install with a timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,8 +123,22 @@ jobs:
           cat test-failures.log >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "No failure log found"
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+        timeout-minutes: 5
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+        timeout-minutes: 5
 
       - name: Run Playwright E2E tests
         run: npm run test:e2e


### PR DESCRIPTION
## Summary
- Cherry-pick of 19a8c80a from the v18 line (`main`/`dev`).
- apt-get against the runner's azure.archive.ubuntu.com mirror is flaky (49s vs 812s on identical runs on PR #391, and an outright hang past an hour on PR #397).
- Caches `~/.cache/ms-playwright` to skip the browser download on most runs, scopes the install to chromium only (the sole browser the e2e suite uses), and adds `timeout-minutes` so a bad mirror fails fast instead of hanging the job.

## Test plan
- [x] CI (Test Suite / Playwright E2E job) exercises this directly