### PR TITLE
chore: require a tracked issue when deferring new-endpoint tools in upgrade-umbraco

### DIFF
--- a/.claude/commands/upgrade-umbraco.md
+++ b/.claude/commands/upgrade-umbraco.md
@@ -115,6 +115,13 @@ For each new endpoint identified in step 6, decide:
 - Is it covered by an existing tool? (e.g. `getDataTypeBatch` overlaps with the existing `getItemDataType` items endpoint, but returns full `DataTypeResponseModel` objects rather than lightweight items — both are useful.)
 - Is it a meaningful new capability for an LLM caller?
 
+Default to adding a tool. Treat "defer" as the exception that needs a reason, not the default path — a past upgrade (17.6, PR #334 on `v17/dev`) judged 7 new endpoints as "convenience variants" not worth tools, said so only in the PR description, and that follow-up was never picked up again; the tools were still missing months later.
+
+**If you decide not to add a tool for a new endpoint in this PR** (out of time, wants a design discussion, etc.), you MUST do both of the following before finishing the upgrade — noting it in the PR description only is not enough, because nothing tracks PR prose:
+
+1. File a GitHub issue for it (`gh issue create`) titled something like "Add MCP tools for new Umbraco X.Y endpoints (deferred from upgrade PR #N)", listing each deferred endpoint, its generated client function name (from step 6's diff), and a one-line reason for deferring.
+2. Link that issue in the upgrade PR description under a "Deferred follow-up" heading.
+
 When adding tools, follow the conventions in this codebase (tools live under `src/umbraco-api/tools/<entity>/{get,post,put,delete,items,folders}/`, registered in the entity `index.ts`):
 
 - Use `withStandardDecorators` and `ToolDefinition` (see `.claude/commands/migrate-tools.md`).


### PR DESCRIPTION
## Summary

Companion to #413 on `v17/dev`. Tightens step 9 of `/upgrade-umbraco` so a deferred "don't add a tool for this new endpoint" decision can't silently disappear.

### Background

The 17.6.0-rc upgrade on `v17/dev` (#334) correctly identified 7 new endpoints in its API-surface diff, but decided not to add tools for them, noting only in the PR description that it was "follow-up work." Nothing tracked that follow-up, so it was never picked up — the tools were still missing when it was raised independently, months after #334 merged. This branch's own 18.1 upgrade (#314) added tools for the same API surface at the time, so `dev` doesn't have the gap — but the skill itself had no guardrail against it happening again on either line.

### Change

Step 9 now requires, when deferring tool creation for a new endpoint:
1. Filing a GitHub issue listing the deferred endpoint(s), their generated client function names, and the reason for deferring.
2. Linking that issue in the upgrade PR under a "Deferred follow-up" heading.

Docs-only change, no code/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)