### PR TITLE
release: 17.6.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.6.2",
+    "version": "17.6.3",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.6.2",
+      "version": "17.6.3",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/.claude/commands/upgrade-umbraco.md
+++ b/.claude/commands/upgrade-umbraco.md
@@ -113,12 +113,20 @@ For each new endpoint identified in step 6, decide:
 - Is it covered by an existing tool? (e.g. `getDataTypeBatch` overlaps with the existing `getItemDataType` items endpoint, but returns full `DataTypeResponseModel` objects rather than lightweight items — both are useful.)
 - Is it a meaningful new capability for an LLM caller?
 
+Default to adding a tool. Treat "defer" as the exception that needs a reason, not the default path — a past upgrade (17.6, PR #334) judged 7 new endpoints as "convenience variants" not worth tools, said so only in the PR description, and that follow-up was never picked up again; the tools were still missing months later.
+
+**If you decide not to add a tool for a new endpoint in this PR** (out of time, wants a design discussion, etc.), you MUST do both of the following before finishing the upgrade — noting it in the PR description only is not enough, because nothing tracks PR prose:
+
+1. File a GitHub issue for it (`gh issue create`) titled something like "Add MCP tools for new Umbraco X.Y endpoints (deferred from upgrade PR #N)", listing each deferred endpoint, its generated client function name (from step 6's diff), and a one-line reason for deferring.
+2. Link that issue in the upgrade PR description under a "Deferred follow-up" heading.
+
 When adding tools, follow the conventions in this codebase (tools live under `src/umbraco-api/tools/<entity>/{get,post,put,delete,items,folders}/`, registered in the entity `index.ts`):
 
 - Use `withStandardDecorators` and `ToolDefinition` (see `.claude/commands/migrate-tools.md`).
 - For array responses, wrap in `z.object({ items: ... })`.
 - Use `executeGetApiCall` / `executeGetItemsApiCall` / `executeVoidApiCall` from the SDK.
 - Add the tool import + registration to the entity's `index.ts` and respect the existing `AuthorizationPolicies` / `slices` pattern.
+- **This branch is the v17 LTS line and supports the whole 17.x range, not just the version you just upgraded to.** If the new endpoint was introduced mid-line (check the Umbraco-CMS source: `git log --oneline <prev-tag>..<new-tag> -- src/Umbraco.Cms.Api.Management/Controllers`), gate its tool registration behind `isUmbracoAtLeast(major, minor)` from `runtime-context.ts` in the entity's `index.ts`, following the existing `GetMediaTypeSchemaTool` / `GetDataTypeSchemaTool` pattern (introduced at 17.4). Do not register it unconditionally — older 17.x instances on this branch will 404 on the route.
 
 After each tool, add a smoke test under `src/umbraco-api/tools/<entity>/__tests__/` mirroring the existing builder + helper conventions (Dictionary is the gold standard — see `.claude/memories/cursor-mcp-testing.md`). The integration test should:
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -40,4 +40,4 @@ jobs:
           esac
           git tag "$VERSION"
           git push origin "$VERSION"
-          gh release create "$VERSION" --title "$VERSION" --generate-notes $PRERELEASE_FLAG
+          gh release create "$VERSION" --title "$VERSION" --generate-notes --latest=false $PRERELEASE_FLAG

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,43 @@
+name: release-tag
+
+on:
+  push:
+    branches: [v17/main]
+
+permissions:
+  contents: write # push tags + create releases
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so we can see whether the tag already exists
+
+      - name: Read version
+        id: v
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether tag already exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.v.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag + GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ steps.v.outputs.version }}"
+          PRERELEASE_FLAG=""
+          case "$VERSION" in
+            *-alpha*|*-beta*|*-rc*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" --title "$VERSION" --generate-notes $PRERELEASE_FLAG

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -138,52 +138,6 @@ stages:
           displayName: Push to npm with dynamic tagging
           workingDirectory: $(Pipeline.Workspace)/npm-package
 
-- stage: Create_GitHub_Release
-  displayName: GitHub release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/v17/main'))
-  dependsOn:
-    - Deploy_Npm
-  jobs:
-    - job: Release
-      displayName: Create GitHub Release
-      variables:
-        isStableRelease: $[ stageDependencies.Deploy_Npm.Publish.outputs['npmPublish.isStable'] ]
-      steps:
-        - checkout: self
-        - task: NodeTool@0
-          displayName: 'Use Node.js $(nodeVersion)'
-          inputs:
-            versionSpec: '$(nodeVersion)'
-        - script: |
-            VERSION=$(node -p "require('./package.json').version")
-            TAG="v${VERSION}"
-
-            # Determine if this is a prerelease
-            if [ "$(isStableRelease)" = "true" ]; then
-              PRERELEASE_FLAG=""
-            else
-              PRERELEASE_FLAG="--prerelease"
-            fi
-
-            # Generate release notes from commits since last tag
-            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-            if [ -n "$LAST_TAG" ]; then
-              NOTES=$(git log ${LAST_TAG}..HEAD --oneline --no-merges | sed 's/^/- /')
-            else
-              NOTES="Initial release"
-            fi
-
-            echo "Creating GitHub release ${TAG}"
-            gh release create "${TAG}" \
-              --target v17/main \
-              --title "${TAG}" \
-              --notes "${NOTES}" \
-              --latest=false \
-              ${PRERELEASE_FLAG}
-          displayName: 'Create GitHub Release'
-          env:
-            GH_TOKEN: $(MCP_REGISTRY_GITHUB_TOKEN)
-
 # MCP Registry publishing is temporarily disabled — the registry auth token has
 # expired/is invalid, and publish steps were failing. Re-enable once a valid
 # MCP_REGISTRY_GITHUB_TOKEN is in place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.2",
+  "version": "17.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.6.2",
+      "version": "17.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.2",
+  "version": "17.6.3",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.6.2",
+  "version": "17.6.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.6.2",
+      "version": "17.6.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/umbraco-api/tools/document/__tests__/__snapshots__/create-and-publish-document.test.ts.snap
+++ b/src/umbraco-api/tools/document/__tests__/__snapshots__/create-and-publish-document.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create-and-publish-document should create and publish an invariant document using the default culturesToPublish 1`] = `
+{
+  "content": [],
+  "structuredContent": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "message": "Document created and published successfully",
+  },
+}
+`;
+
+exports[`create-and-publish-document should create and publish an invariant document using the default culturesToPublish 2`] = `
+{
+  "ancestors": [],
+  "createDate": "NORMALIZED_DATE",
+  "documentType": {
+    "collection": null,
+    "icon": "icon-home color-blue",
+    "id": "00000000-0000-0000-0000-000000000000",
+  },
+  "flags": [],
+  "hasChildren": false,
+  "id": "00000000-0000-0000-0000-000000000000",
+  "isProtected": false,
+  "isTrashed": false,
+  "noAccess": false,
+  "parent": null,
+  "variants": [
+    {
+      "culture": null,
+      "flags": [],
+      "id": "00000000-0000-0000-0000-000000000000",
+      "name": "_Test CreateAndPublishDocument",
+      "state": "Published",
+    },
+  ],
+}
+`;
+
+exports[`create-and-publish-document should create and publish an invariant document with an explicit empty culturesToPublish array 1`] = `
+{
+  "content": [],
+  "structuredContent": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "message": "Document created and published successfully",
+  },
+}
+`;

--- a/src/umbraco-api/tools/document/__tests__/__snapshots__/sort-document-children.test.ts.snap
+++ b/src/umbraco-api/tools/document/__tests__/__snapshots__/sort-document-children.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sort-document-children should sort a document's children by Name in Descending order 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+}
+`;

--- a/src/umbraco-api/tools/document/__tests__/__snapshots__/sort-document-root-children.test.ts.snap
+++ b/src/umbraco-api/tools/document/__tests__/__snapshots__/sort-document-root-children.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sort-document-root-children should sort root-level documents by Name in Descending order 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+}
+`;

--- a/src/umbraco-api/tools/document/__tests__/__snapshots__/update-and-publish-document.test.ts.snap
+++ b/src/umbraco-api/tools/document/__tests__/__snapshots__/update-and-publish-document.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`update-and-publish-document should handle updating and publishing a non-existent document 1`] = `
+{
+  "content": [],
+  "isError": true,
+  "structuredContent": {
+    "operationStatus": "NotFound",
+    "status": 404,
+    "title": "The content could not be found",
+    "type": "Error",
+  },
+}
+`;
+
+exports[`update-and-publish-document should update and publish an invariant document with an empty culturesToPublish array 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+}
+`;

--- a/src/umbraco-api/tools/document/__tests__/create-and-publish-document.test.ts
+++ b/src/umbraco-api/tools/document/__tests__/create-and-publish-document.test.ts
@@ -1,0 +1,80 @@
+import CreateAndPublishDocumentTool from "../post/create-and-publish-document.js";
+import { DocumentTestHelper } from "./helpers/document-test-helper.js";
+import { ROOT_DOCUMENT_TYPE_ID } from "../../../../constants/constants.js";
+import {
+  createMockRequestHandlerExtra,
+  createSnapshotResult,
+  normalizeObject,
+  setupTestEnvironment,
+  validateToolResponse,
+} from "@umbraco-cms/mcp-server-sdk/testing";
+
+const TEST_DOCUMENT_NAME = "_Test CreateAndPublishDocument";
+
+describe("create-and-publish-document", () => {
+  setupTestEnvironment();
+
+  afterEach(async () => {
+    await DocumentTestHelper.cleanup(TEST_DOCUMENT_NAME);
+  });
+
+  it("should create and publish an invariant document using the default culturesToPublish", async () => {
+    // Arrange: invariant document type, culturesToPublish omitted entirely.
+    // Umbraco only accepts real culture codes for culturesToPublish (wildcards/nulls are
+    // rejected), so for invariant content the tool must default to an empty array to
+    // publish the single invariant variant.
+    const docModel = {
+      documentTypeId: ROOT_DOCUMENT_TYPE_ID,
+      name: TEST_DOCUMENT_NAME,
+      parentId: undefined,
+      templateId: undefined,
+      cultures: undefined,
+      culturesToPublish: undefined,
+      values: [],
+    };
+
+    // Act
+    const result = await CreateAndPublishDocumentTool.handler(docModel, createMockRequestHandlerExtra());
+
+    // Assert
+    const responseData = validateToolResponse(CreateAndPublishDocumentTool, result);
+    const documentId = responseData.id;
+    expect(createSnapshotResult(result, documentId)).toMatchSnapshot();
+
+    const item = await DocumentTestHelper.findDocument(TEST_DOCUMENT_NAME);
+    expect(item).toBeDefined();
+    const norm = {
+      ...normalizeObject(item!),
+      createDate: "NORMALIZED_DATE",
+    };
+    expect(norm).toMatchSnapshot();
+
+    const isPublished = item!.variants.some((v: any) => v.state === "Published");
+    expect(isPublished).toBe(true);
+  });
+
+  it("should create and publish an invariant document with an explicit empty culturesToPublish array", async () => {
+    // Arrange
+    const docModel = {
+      documentTypeId: ROOT_DOCUMENT_TYPE_ID,
+      name: TEST_DOCUMENT_NAME,
+      parentId: undefined,
+      templateId: undefined,
+      cultures: undefined,
+      culturesToPublish: [],
+      values: [],
+    };
+
+    // Act
+    const result = await CreateAndPublishDocumentTool.handler(docModel, createMockRequestHandlerExtra());
+
+    // Assert
+    const responseData = validateToolResponse(CreateAndPublishDocumentTool, result);
+    expect(createSnapshotResult(result, responseData.id)).toMatchSnapshot();
+
+    const item = await DocumentTestHelper.findDocument(TEST_DOCUMENT_NAME);
+    expect(item).toBeDefined();
+    const isPublished = item!.variants.some((v: any) => v.state === "Published");
+    expect(isPublished).toBe(true);
+  });
+});

--- a/src/umbraco-api/tools/document/__tests__/sort-document-children.test.ts
+++ b/src/umbraco-api/tools/document/__tests__/sort-document-children.test.ts
@@ -1,0 +1,62 @@
+import SortDocumentChildrenTool from "../put/sort-document-children.js";
+import { DocumentBuilder } from "./helpers/document-builder.js";
+import { DocumentTestHelper } from "./helpers/document-test-helper.js";
+import {
+  createMockRequestHandlerExtra,
+  setupTestEnvironment,
+} from "@umbraco-cms/mcp-server-sdk/testing";
+
+const TEST_ROOT_NAME = "_Test SortDocumentChildren Root";
+const TEST_CHILD_NAMES = [
+  "_Test SortDocumentChildren Child A",
+  "_Test SortDocumentChildren Child B",
+  "_Test SortDocumentChildren Child C"
+];
+
+describe("sort-document-children", () => {
+  setupTestEnvironment();
+
+  let rootId: string;
+
+  beforeEach(async () => {
+    // Create root
+    const rootBuilder = await new DocumentBuilder()
+      .withName(TEST_ROOT_NAME)
+      .withRootDocumentType()
+      .create();
+    await rootBuilder.publish();
+    rootId = rootBuilder.getId();
+    // Create children - insert in ascending name order so a Name/Descending sort
+    // must actually change the order for the assertion to be meaningful.
+    for (const name of TEST_CHILD_NAMES) {
+      const childBuilder = await new DocumentBuilder()
+        .withName(name)
+        .withContentDocumentType()
+        .withParent(rootId)
+        .create();
+      await childBuilder.publish();
+    }
+  });
+
+  afterEach(async () => {
+    await DocumentTestHelper.cleanup(TEST_ROOT_NAME);
+    for (const name of TEST_CHILD_NAMES) {
+      await DocumentTestHelper.cleanup(name);
+    }
+  });
+
+  it("should sort a document's children by Name in Descending order", async () => {
+    const result = await SortDocumentChildrenTool.handler(
+      {
+        id: rootId,
+        data: { culture: null, field: "Name", direction: "Descending" },
+      },
+      createMockRequestHandlerExtra()
+    );
+    expect(result).toMatchSnapshot();
+
+    const fetched = await DocumentTestHelper.getChildren(rootId, 10);
+    const fetchedNames = fetched.map(child => DocumentTestHelper.getNameFromItem(child));
+    expect(fetchedNames).toEqual([...TEST_CHILD_NAMES].sort().reverse());
+  });
+});

--- a/src/umbraco-api/tools/document/__tests__/sort-document-root-children.test.ts
+++ b/src/umbraco-api/tools/document/__tests__/sort-document-root-children.test.ts
@@ -1,0 +1,52 @@
+import SortDocumentRootChildrenTool from "../put/sort-document-root-children.js";
+import { DocumentBuilder } from "./helpers/document-builder.js";
+import { DocumentTestHelper } from "./helpers/document-test-helper.js";
+import { UmbracoManagementClient } from "@umb-management-client";
+import {
+  createMockRequestHandlerExtra,
+  setupTestEnvironment,
+} from "@umbraco-cms/mcp-server-sdk/testing";
+
+const TEST_ROOT_NAMES = [
+  "_Test SortDocumentRootChildren A",
+  "_Test SortDocumentRootChildren B",
+  "_Test SortDocumentRootChildren C"
+];
+
+describe("sort-document-root-children", () => {
+  setupTestEnvironment();
+
+  beforeEach(async () => {
+    // Create root-level documents in ascending name order so a Name/Descending sort
+    // must actually change the order for the assertion to be meaningful.
+    for (const name of TEST_ROOT_NAMES) {
+      const builder = await new DocumentBuilder()
+        .withName(name)
+        .withRootDocumentType()
+        .create();
+      await builder.publish();
+    }
+  });
+
+  afterEach(async () => {
+    for (const name of TEST_ROOT_NAMES) {
+      await DocumentTestHelper.cleanup(name);
+    }
+  });
+
+  it("should sort root-level documents by Name in Descending order", async () => {
+    const result = await SortDocumentRootChildrenTool.handler(
+      { culture: null, field: "Name", direction: "Descending" },
+      createMockRequestHandlerExtra()
+    );
+    expect(result).toMatchSnapshot();
+
+    const client = UmbracoManagementClient.getClient();
+    const rootResponse = await client.getTreeDocumentRoot({ take: 100 });
+    const fetchedNames = rootResponse.items
+      .map(item => DocumentTestHelper.getNameFromItem(item))
+      .filter(name => TEST_ROOT_NAMES.includes(name));
+
+    expect(fetchedNames).toEqual([...TEST_ROOT_NAMES].sort().reverse());
+  });
+});

--- a/src/umbraco-api/tools/document/__tests__/update-and-publish-document.test.ts
+++ b/src/umbraco-api/tools/document/__tests__/update-and-publish-document.test.ts
@@ -1,0 +1,72 @@
+import UpdateAndPublishDocumentTool from "../put/update-and-publish-document.js";
+import { DocumentBuilder } from "./helpers/document-builder.js";
+import { DocumentTestHelper } from "./helpers/document-test-helper.js";
+import { ROOT_DOCUMENT_TYPE_ID } from "../../../../constants/constants.js";
+import {
+  BLANK_UUID,
+} from "@umbraco-cms/mcp-server-sdk";
+import {
+  createMockRequestHandlerExtra,
+  setupTestEnvironment,
+} from "@umbraco-cms/mcp-server-sdk/testing";
+
+describe("update-and-publish-document", () => {
+  const TEST_DOCUMENT_NAME = "_Test UpdateAndPublishDocument";
+  const UPDATED_DOCUMENT_NAME = "_Test UpdateAndPublishDocument Updated";
+  setupTestEnvironment();
+
+  afterEach(async () => {
+    await DocumentTestHelper.cleanup(TEST_DOCUMENT_NAME);
+    await DocumentTestHelper.cleanup(UPDATED_DOCUMENT_NAME);
+  });
+
+  it("should update and publish an invariant document with an empty culturesToPublish array", async () => {
+    // Arrange: create an unpublished invariant document.
+    const builder = await new DocumentBuilder()
+      .withName(TEST_DOCUMENT_NAME)
+      .withDocumentType(ROOT_DOCUMENT_TYPE_ID)
+      .create();
+
+    // Umbraco only accepts real culture codes for culturesToPublish (wildcards/nulls are
+    // rejected). For invariant content, an empty array publishes the invariant variant.
+    const updateModel = new DocumentBuilder()
+      .withName(UPDATED_DOCUMENT_NAME)
+      .withDocumentType(ROOT_DOCUMENT_TYPE_ID)
+      .build();
+
+    // Act
+    const result = await UpdateAndPublishDocumentTool.handler(
+      {
+        id: builder.getId(),
+        data: { ...updateModel, culturesToPublish: [] },
+      },
+      createMockRequestHandlerExtra()
+    );
+
+    // Assert
+    expect(result).toMatchSnapshot();
+
+    const found = await DocumentTestHelper.findDocument(UPDATED_DOCUMENT_NAME);
+    expect(found).toBeDefined();
+    expect(found!.id).toBe(builder.getId());
+    const isPublished = found!.variants.some((v: any) => v.state === "Published");
+    expect(isPublished).toBe(true);
+  });
+
+  it("should handle updating and publishing a non-existent document", async () => {
+    const updateModel = new DocumentBuilder()
+      .withName(UPDATED_DOCUMENT_NAME)
+      .withDocumentType(ROOT_DOCUMENT_TYPE_ID)
+      .build();
+
+    const result = await UpdateAndPublishDocumentTool.handler(
+      {
+        id: BLANK_UUID,
+        data: { ...updateModel, culturesToPublish: [] },
+      },
+      createMockRequestHandlerExtra()
+    );
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/umbraco-api/tools/document/index.ts
+++ b/src/umbraco-api/tools/document/index.ts
@@ -24,18 +24,22 @@ import PostDocumentPublicAccessTool from "./post/post-document-public-access.js"
 import ValidateDocumentTool from "./post/validate-document.js";
 import CopyDocumentTool from "./post/copy-document.js";
 import CreateDocumentTool from "./post/create-document.js";
+import CreateAndPublishDocumentTool from "./post/create-and-publish-document.js";
 import PutDocumentPublicAccessTool from "./put/put-document-public-access.js";
 import PutDocumentDomainsTool from "./put/put-document-domains.js";
 import PutDocumentNotificationsTool from "./put/put-document-notifications.js";
 import PublishDocumentWithDescendantsTool from "./put/publish-document-with-descendants.js";
 import UnpublishDocumentTool from "./put/unpublish-document.js";
 import SortDocumentTool from "./put/sort-document.js";
+import SortDocumentChildrenTool from "./put/sort-document-children.js";
+import SortDocumentRootChildrenTool from "./put/sort-document-root-children.js";
 import MoveDocumentTool from "./put/move-document.js";
 import PublishDocumentTool from "./put/publish-document.js";
 import EmptyRecycleBinTool from "./put/empty-recycle-bin.js";
 import RestoreFromRecycleBinTool from "./put/restore-from-recycle-bin.js";
 import MoveToRecycleBinTool from "./put/move-to-recycle-bin.js";
 import UpdateDocumentTool from "./put/update-document.js";
+import UpdateAndPublishDocumentTool from "./put/update-and-publish-document.js";
 import UpdateDocumentPropertiesTool from "./put/update-document-properties.js";
 import UpdateDocumentNameTool from "./put/update-document-name.js";
 import UpdateBlockPropertyTool from "./put/update-block-property.js";
@@ -49,6 +53,7 @@ import GetRecycleBinChildrenTool from "./items/get/get-recycle-bin-children.js";
 import GetDocumentRecycleBinSiblingsTool from "./items/get/get-recycle-bin-siblings.js";
 import { AuthorizationPolicies } from "auth/umbraco-auth-policies.js";
 import { CurrentUserResponseModel } from "@/umbraco-api/schemas/index.js";
+import { isUmbracoAtLeast } from "../../runtime-context.js";
 import {
   type ToolCollectionExport,
   type ToolDefinition,
@@ -71,6 +76,10 @@ export const DocumentCollection: ToolCollectionExport = {
     tools.push(GetDocumentTypeSchemaTool);
     tools.push(CopyDocumentTool);
     tools.push(CreateDocumentTool);
+    // create-and-publish endpoint introduced in Umbraco 17.6; omit on older versions.
+    if (isUmbracoAtLeast(17, 6)) {
+      tools.push(CreateAndPublishDocumentTool);
+    }
     tools.push(PostDocumentPublicAccessTool);
     tools.push(DeleteDocumentTool);
     tools.push(DeleteDocumentPublicAccessTool);
@@ -85,8 +94,17 @@ export const DocumentCollection: ToolCollectionExport = {
     tools.push(PublishDocumentTool);
     tools.push(PublishDocumentWithDescendantsTool);
     tools.push(SortDocumentTool);
+    // sort-children endpoints introduced in Umbraco 17.6; omit on older versions.
+    if (isUmbracoAtLeast(17, 6)) {
+      tools.push(SortDocumentChildrenTool);
+      tools.push(SortDocumentRootChildrenTool);
+    }
     tools.push(UnpublishDocumentTool);
     tools.push(UpdateDocumentTool);
+    // update-and-publish endpoint introduced in Umbraco 17.6; omit on older versions.
+    if (isUmbracoAtLeast(17, 6)) {
+      tools.push(UpdateAndPublishDocumentTool);
+    }
     tools.push(UpdateDocumentPropertiesTool);
     tools.push(UpdateDocumentNameTool);
     tools.push(UpdateBlockPropertyTool);

--- a/src/umbraco-api/tools/document/post/create-and-publish-document.ts
+++ b/src/umbraco-api/tools/document/post/create-and-publish-document.ts
@@ -1,0 +1,222 @@
+import { UmbracoManagementClient } from "@umb-management-client";
+import { CreateAndPublishDocumentRequestModel, CurrentUserResponseModel, ProblemDetails } from "@/umbraco-api/schemas/index.js";
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { UmbracoDocumentPermissions } from "../constants.js";
+import {
+  type ToolDefinition,
+  CAPTURE_RAW_HTTP_RESPONSE,
+  createToolResult,
+  createToolResultError,
+  withStandardDecorators,
+  type HttpResponse,
+} from "@umbraco-cms/mcp-server-sdk";
+
+export const createAndPublishOutputSchema = z.object({
+  message: z.string(),
+  id: z.string().guid()
+});
+
+const createAndPublishDocumentSchema = z.object({
+  documentTypeId: z.string().uuid("Must be a valid document type type UUID"),
+  parentId: z.string().uuid("Must be a valid document UUID").optional(),
+  name: z.string(),
+  templateId: z
+    .string()
+    .uuid("Must be a valid template UUID")
+    .optional()
+    .describe(
+      "Optional template ID to apply to the document. If omitted, the document type's default template is applied automatically. Provide a value only when you need a specific allowed template other than the default."
+    ),
+  cultures: z.array(z.string()).optional().describe("Array of culture codes. If not provided or empty array, will create single variant with null culture."),
+  culturesToPublish: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Culture codes to publish immediately after creation. Must contain real culture codes only - wildcards (\"*\") and nulls are rejected by Umbraco. If omitted, defaults to publishing every culture in the cultures array, or an empty array (which publishes the single invariant variant) when the document type does not vary by culture."
+    ),
+  values: z
+    .array(
+      z.object({
+        editorAlias: z.string(),
+        culture: z.string().nullable(),
+        segment: z.string().nullable(),
+        alias: z.string(),
+        value: z.any(),
+      })
+    )
+    .default([]),
+});
+
+const CreateAndPublishDocumentTool = {
+  name: "create-and-publish-document",
+  description: `Creates a document and publishes it in a single operation, with support for multiple cultures.
+
+  Always follow these requirements when creating documents exactly, do not deviate in any way.
+
+  ## COPY-FIRST APPROACH (RECOMMENDED)
+
+  **FIRST: Try to copy an existing document**
+  1. Only use this if copy-document and search-document tools are available
+  2. Use search-document to find documents with the same document type
+  3. If similar documents exist AND copy-document tool is available:
+     - Use copy-document to duplicate the existing structure
+     - Use search-document to find the new document (copy returns empty string, not the new ID)
+     - Update and publish with update-and-publish-document as needed
+
+  **SECOND: Only create from scratch when:**
+  - No similar documents exist in Umbraco
+  - Copy-document tool doesn't exist
+  - You need to create from scratch with unique structure
+
+  Benefits: Preserves structure, inherits properties, maintains consistency with existing content.
+
+  ## Introduction
+
+  This tool creates and publishes documents with multi-culture support:
+  - If cultures parameter is provided, a variant will be created for each culture code
+  - If cultures parameter is not provided or is an empty array, will create a single variant with null culture (original behavior)
+  - IMPORTANT: If workflow approval is required, use create-document followed by initiate-workflow-action instead.
+    This tool bypasses approval workflows and publishes directly to the live site.
+
+  ## Critical Requirements
+
+  ### Document Type Analysis (When Creating from Scratch)
+  1. Use get-document-type-by-id to understand the document type structure and required properties
+  2. Ensure all required properties are included in the values array
+
+  ### Document Types and Data Types
+  1. BEFORE creating any new document type, ALWAYS search for existing ones using get-all-document-types
+  2. BEFORE creating any new data type, ALWAYS search for existing ones using get-all-data-types
+  3. ONLY create a new document type or data type if NO suitable existing ones are found
+  4. If similar types exist, inform the user and suggest using the existing types instead
+  5. Creation of new types should be a last resort when nothing suitable exists
+
+  ### Parent ID Handling
+  For document types with allowedAsRoot=true, DO NOT include the parentId parameter at all in the function call.
+  When adding a parent, first find the parent using get-document-root or get-document-children and then use the id of the parent in the parentId parameter. Alway makes sure that the id is valid.
+
+  ### Values Matching
+  - Values must match the aliases of the document type structure
+  - Block lists, Block Grids and Rich Text Blocks items and settings must match the defined blocks document type structures
+
+  ### Unique Keys
+  All generated keys must be unique and randomly generated.
+
+  ### Cultures To Publish
+  - culturesToPublish controls which of the created variants get published immediately.
+  - Umbraco only accepts real culture codes here - wildcards ("*") and nulls are rejected with an error.
+  - When the document type does not vary by culture (invariant content), pass an empty array \`[]\` to publish the single invariant variant (this is the default when omitted).
+  - When the document type varies by culture, culturesToPublish defaults to every culture supplied in the cultures array. Pass a subset to only publish some of the created variants.
+
+  ## Property Editor Values Reference
+
+  When creating documents, you need to provide property values that match the property editors defined in the document type.
+
+  IMPORTANT: Use the get-document-type-schema tool to:
+  - Get the JSON Schema describing the expected property structure for a specific document type
+  - The schema includes all property definitions and their value formats
+  - Use the schema to construct the correct values array for your document
+
+  The values parameter is an array of property value objects following this structure:
+  {
+    "editorAlias": "Umbraco.TextBox",  // The property editor type
+    "culture": null,                    // Document-specific - culture code or null
+    "segment": null,                    // Document-specific - segment or null
+    "alias": "propertyAlias",          // Property alias from document type
+    "value": "your value here"         // Value matching the schema structure
+  }
+
+  ## Default Template
+
+  The document type's default template is applied automatically. Pass an explicit \`templateId\` only when you need a specific allowed template other than the default. If the document type has no default template, the document is created without one.
+  `,
+  inputSchema: createAndPublishDocumentSchema.shape,
+  outputSchema: createAndPublishOutputSchema.shape,
+  slices: ['create'],
+  enabled: (user: CurrentUserResponseModel) =>
+    user.fallbackPermissions.includes(UmbracoDocumentPermissions.Create) &&
+    user.fallbackPermissions.includes(UmbracoDocumentPermissions.Publish),
+  handler: (async (model: z.infer<typeof createAndPublishDocumentSchema>) => {
+    const client = UmbracoManagementClient.getClient();
+
+    const documentId = uuidv4();
+
+    // Determine cultures to use
+    let culturesToUse: (string | null)[] = [];
+
+    if (model.cultures === undefined || model.cultures.length === 0) {
+      // If cultures not provided or empty array, use original behavior (null culture)
+      culturesToUse = [null];
+    } else {
+      // Use provided cultures
+      culturesToUse = model.cultures;
+    }
+
+    // Create variants for each culture
+    const variants = culturesToUse.map(culture => ({
+      culture,
+      name: model.name,
+      segment: null,
+    }));
+
+    // Determine which cultures should be published immediately.
+    // Umbraco rejects wildcards ("*") and nulls here - only real culture codes are valid.
+    // For invariant content, an empty array publishes the single invariant variant.
+    let culturesToPublish: string[];
+    if (model.culturesToPublish && model.culturesToPublish.length > 0) {
+      culturesToPublish = model.culturesToPublish;
+    } else if (model.cultures === undefined || model.cultures.length === 0) {
+      culturesToPublish = [];
+    } else {
+      culturesToPublish = model.cultures;
+    }
+
+    // Resolve the template: explicit override wins; otherwise use the
+    // document type's default template (which may itself be null).
+    let template: { id: string } | null;
+    if (model.templateId) {
+      template = { id: model.templateId };
+    } else {
+      const docType = await client.getDocumentTypeById(model.documentTypeId);
+      template = docType.defaultTemplate?.id
+        ? { id: docType.defaultTemplate.id }
+        : null;
+    }
+
+    const payload: CreateAndPublishDocumentRequestModel = {
+      id: documentId,
+      documentType: {
+        id: model.documentTypeId,
+      },
+      parent: model.parentId
+        ? {
+          id: model.parentId,
+        }
+        : undefined,
+      template,
+      culturesToPublish,
+      values: model.values,
+      variants,
+    };
+
+    // Get full response to check status
+    const response = await client.postDocumentCreateAndPublish(payload, CAPTURE_RAW_HTTP_RESPONSE) as unknown as HttpResponse<ProblemDetails | void>;
+
+    // Check if the document was created and published successfully
+    if (response.status === 201 || response.status === 200) {
+      return createToolResult({
+        message: "Document created and published successfully",
+        id: documentId
+      });
+    } else {
+      // Document creation/publishing failed
+      return createToolResultError(response.data || {
+        status: response.status,
+        detail: response.statusText
+      });
+    }
+  }),
+} satisfies ToolDefinition<typeof createAndPublishDocumentSchema.shape, typeof createAndPublishOutputSchema.shape>;
+
+export default withStandardDecorators(CreateAndPublishDocumentTool);

--- a/src/umbraco-api/tools/document/put/sort-document-children.ts
+++ b/src/umbraco-api/tools/document/put/sort-document-children.ts
@@ -1,0 +1,38 @@
+import {
+  putDocumentByIdSortChildrenParams,
+  putDocumentByIdSortChildrenBody,
+} from "@/umbraco-api/umbracoManagementAPI.zod.js";
+import { CurrentUserResponseModel } from "@/umbraco-api/schemas/index.js";
+import { UmbracoDocumentPermissions } from "../constants.js";
+import { z } from "zod";
+import {
+  type ToolDefinition,
+  CAPTURE_RAW_HTTP_RESPONSE,
+  executeVoidApiCall,
+  withStandardDecorators,
+} from "@umbraco-cms/mcp-server-sdk";
+
+const inputSchema = {
+  id: putDocumentByIdSortChildrenParams.shape.id,
+  data: z.object(putDocumentByIdSortChildrenBody.shape),
+};
+
+const SortDocumentChildrenTool = {
+  name: "sort-document-children",
+  description: `Sorts the children of the document identified by Id by a system field (Name, CreateDate or UpdateDate) in the given direction (Ascending or Descending).
+
+  This is DIFFERENT from sort-document: sort-document reorders children according to an explicit list of ids and sort orders you provide, whereas sort-document-children sorts every child of {id} automatically by the chosen field and direction - no explicit ordering is required.
+
+  When sorting by Name, an optional culture selects which variant name to sort by; the culture is not validated, so children that do not vary by it (or an unrecognised culture) fall back to the invariant name.`,
+  inputSchema: inputSchema,
+  annotations: {},
+  slices: ['sort'],
+  enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Sort),
+  handler: (async (model: { id: string; data: any }) => {
+    return executeVoidApiCall((client) =>
+      client.putDocumentByIdSortChildren(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
+    );
+  }),
+} satisfies ToolDefinition<typeof inputSchema>;
+
+export default withStandardDecorators(SortDocumentChildrenTool);

--- a/src/umbraco-api/tools/document/put/sort-document-root-children.ts
+++ b/src/umbraco-api/tools/document/put/sort-document-root-children.ts
@@ -1,0 +1,30 @@
+import { putDocumentRootSortChildrenBody } from "@/umbraco-api/umbracoManagementAPI.zod.js";
+import { CurrentUserResponseModel } from "@/umbraco-api/schemas/index.js";
+import { UmbracoDocumentPermissions } from "../constants.js";
+import { z } from "zod";
+import {
+  type ToolDefinition,
+  CAPTURE_RAW_HTTP_RESPONSE,
+  executeVoidApiCall,
+  withStandardDecorators,
+} from "@umbraco-cms/mcp-server-sdk";
+
+const SortDocumentRootChildrenTool = {
+  name: "sort-document-root-children",
+  description: `Sorts the root-level documents by a system field (Name, CreateDate or UpdateDate) in the given direction (Ascending or Descending).
+
+  This is the root-level equivalent of sort-document-children: it sorts every document at the root of the content tree automatically by the chosen field and direction - no explicit ordering is required. This is DIFFERENT from sort-document, which reorders documents according to an explicit list of ids and sort orders you provide.
+
+  When sorting by Name, an optional culture selects which variant name to sort by; the culture is not validated, so documents that do not vary by it (or an unrecognised culture) fall back to the invariant name.`,
+  inputSchema: putDocumentRootSortChildrenBody.shape,
+  annotations: {},
+  slices: ['sort'],
+  enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Sort),
+  handler: (async (model: z.infer<typeof putDocumentRootSortChildrenBody>) => {
+    return executeVoidApiCall((client) =>
+      client.putDocumentRootSortChildren(model, CAPTURE_RAW_HTTP_RESPONSE)
+    );
+  }),
+} satisfies ToolDefinition<typeof putDocumentRootSortChildrenBody.shape>;
+
+export default withStandardDecorators(SortDocumentRootChildrenTool);

--- a/src/umbraco-api/tools/document/put/update-and-publish-document.ts
+++ b/src/umbraco-api/tools/document/put/update-and-publish-document.ts
@@ -1,0 +1,50 @@
+import {
+  putDocumentByIdUpdateAndPublishParams,
+  putDocumentByIdUpdateAndPublishBody,
+} from "@/umbraco-api/umbracoManagementAPI.zod.js";
+import { z } from "zod";
+import { CurrentUserResponseModel } from "@/umbraco-api/schemas/index.js";
+import { UmbracoDocumentPermissions } from "../constants.js";
+import {
+  type ToolDefinition,
+  CAPTURE_RAW_HTTP_RESPONSE,
+  executeVoidApiCall,
+  withStandardDecorators,
+} from "@umbraco-cms/mcp-server-sdk";
+
+const inputSchema = {
+  id: putDocumentByIdUpdateAndPublishParams.shape.id,
+  data: z.object(putDocumentByIdUpdateAndPublishBody.shape),
+};
+
+const UpdateAndPublishDocumentTool = {
+  name: "update-and-publish-document",
+  description: `Updates a document by Id and publishes it in a single operation.
+
+  IMPORTANT: If workflow approval is required, use update-document followed by initiate-workflow-action instead.
+  This function bypasses approval workflows and publishes directly to the live site.
+
+  ### Cultures To Publish
+  - culturesToPublish controls which of the document's variants get published.
+  - Umbraco only accepts real culture codes here - wildcards ("*") and nulls are rejected with an error.
+  - When the document does not vary by culture (invariant content), pass an empty array \`[]\` to publish the single invariant variant.
+  - When the document varies by culture, provide the culture codes of the variants you want published.
+
+  If you must use this tool:
+  - Always read the current document value first
+  - Only update the required values
+  - Don't miss any properties from the original document`,
+  inputSchema: inputSchema,
+  annotations: {
+    idempotentHint: true,
+  },
+  slices: ['update'],
+  enabled: (user: CurrentUserResponseModel) => user.fallbackPermissions.includes(UmbracoDocumentPermissions.Publish),
+  handler: (async (model: { id: string; data: any }) => {
+    return executeVoidApiCall((client) =>
+      client.putDocumentByIdUpdateAndPublish(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
+    );
+  }),
+} satisfies ToolDefinition<typeof inputSchema>;
+
+export default withStandardDecorators(UpdateAndPublishDocumentTool);

--- a/src/umbraco-api/tools/media/__tests__/__snapshots__/sort-media-children.test.ts.snap
+++ b/src/umbraco-api/tools/media/__tests__/__snapshots__/sort-media-children.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sort-media-children should sort a media item's children by Name in Descending order 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+}
+`;

--- a/src/umbraco-api/tools/media/__tests__/__snapshots__/sort-media-root-children.test.ts.snap
+++ b/src/umbraco-api/tools/media/__tests__/__snapshots__/sort-media-root-children.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sort-media-root-children should sort root-level media items by Name in Descending order 1`] = `
+{
+  "content": [
+    {
+      "text": "",
+      "type": "text",
+    },
+  ],
+}
+`;

--- a/src/umbraco-api/tools/media/__tests__/sort-media-children.test.ts
+++ b/src/umbraco-api/tools/media/__tests__/sort-media-children.test.ts
@@ -1,0 +1,62 @@
+import SortMediaChildrenTool from "../put/sort-media-children.js";
+import { MediaBuilder } from "./helpers/media-builder.js";
+import { MediaTestHelper } from "./helpers/media-test-helper.js";
+import {
+  createMockRequestHandlerExtra,
+  setupTestEnvironment,
+} from "@umbraco-cms/mcp-server-sdk/testing";
+
+const TEST_ROOT_NAME = "_Test SortMediaChildren Root";
+const TEST_CHILD_NAMES = [
+  "_Test SortMediaChildren Child A",
+  "_Test SortMediaChildren Child B",
+  "_Test SortMediaChildren Child C",
+];
+
+describe("sort-media-children", () => {
+  setupTestEnvironment();
+
+  let rootId: string;
+
+  beforeEach(async () => {
+    const rootBuilder = await new MediaBuilder()
+      .withName(TEST_ROOT_NAME)
+      .withFolderMediaType()
+      .create();
+    rootId = rootBuilder.getId();
+
+    // Create children in ascending name order so a Name/Descending sort
+    // must actually change the order for the assertion to be meaningful.
+    for (const name of TEST_CHILD_NAMES) {
+      await new MediaBuilder()
+        .withName(name)
+        .withFolderMediaType()
+        .withParent(rootId)
+        .create();
+    }
+  });
+
+  afterEach(async () => {
+    await MediaTestHelper.cleanup(TEST_ROOT_NAME);
+    for (const name of TEST_CHILD_NAMES) {
+      await MediaTestHelper.cleanup(name);
+    }
+  });
+
+  it("should sort a media item's children by Name in Descending order", async () => {
+    const result = await SortMediaChildrenTool.handler(
+      {
+        id: rootId,
+        data: { field: "Name", direction: "Descending" },
+      },
+      createMockRequestHandlerExtra()
+    );
+    expect(result).toMatchSnapshot();
+
+    const fetched = await MediaTestHelper.getChildren(rootId, 10);
+    const fetchedNames = fetched.map((child) =>
+      MediaTestHelper.getNameFromItem(child)
+    );
+    expect(fetchedNames).toEqual([...TEST_CHILD_NAMES].sort().reverse());
+  });
+});

--- a/src/umbraco-api/tools/media/__tests__/sort-media-root-children.test.ts
+++ b/src/umbraco-api/tools/media/__tests__/sort-media-root-children.test.ts
@@ -1,0 +1,48 @@
+import SortMediaRootChildrenTool from "../put/sort-media-root-children.js";
+import { MediaBuilder } from "./helpers/media-builder.js";
+import { MediaTestHelper } from "./helpers/media-test-helper.js";
+import { UmbracoManagementClient } from "@umb-management-client";
+import {
+  createMockRequestHandlerExtra,
+  setupTestEnvironment,
+} from "@umbraco-cms/mcp-server-sdk/testing";
+
+const TEST_ROOT_NAMES = [
+  "_Test SortMediaRootChildren A",
+  "_Test SortMediaRootChildren B",
+  "_Test SortMediaRootChildren C",
+];
+
+describe("sort-media-root-children", () => {
+  setupTestEnvironment();
+
+  beforeEach(async () => {
+    // Create root-level media items in ascending name order so a Name/Descending sort
+    // must actually change the order for the assertion to be meaningful.
+    for (const name of TEST_ROOT_NAMES) {
+      await new MediaBuilder().withName(name).withFolderMediaType().create();
+    }
+  });
+
+  afterEach(async () => {
+    for (const name of TEST_ROOT_NAMES) {
+      await MediaTestHelper.cleanup(name);
+    }
+  });
+
+  it("should sort root-level media items by Name in Descending order", async () => {
+    const result = await SortMediaRootChildrenTool.handler(
+      { field: "Name", direction: "Descending" },
+      createMockRequestHandlerExtra()
+    );
+    expect(result).toMatchSnapshot();
+
+    const client = UmbracoManagementClient.getClient();
+    const rootResponse = await client.getTreeMediaRoot({ take: 100 });
+    const fetchedNames = rootResponse.items
+      .map((item) => MediaTestHelper.getNameFromItem(item))
+      .filter((name) => TEST_ROOT_NAMES.includes(name));
+
+    expect(fetchedNames).toEqual([...TEST_ROOT_NAMES].sort().reverse());
+  });
+});

--- a/src/umbraco-api/tools/media/index.ts
+++ b/src/umbraco-api/tools/media/index.ts
@@ -9,6 +9,8 @@ import GetMediaUrlsTool from "./get/get-media-urls.js";
 import ValidateMediaTool from "./post/validate-media.js";
 import ValidateMediaUpdateTool from "./put/validate-media.js";
 import SortMediaTool from "./put/sort-media.js";
+import SortMediaChildrenTool from "./put/sort-media-children.js";
+import SortMediaRootChildrenTool from "./put/sort-media-root-children.js";
 import GetMediaByIdArrayTool from "./get/get-media-by-id-array.js";
 import MoveMediaTool from "./put/move-media.js";
 import GetMediaAncestorsTool from "./items/get/get-ancestors.js";
@@ -72,6 +74,11 @@ export const MediaCollection: ToolCollectionExport = {
       tools.push(ValidateMediaTool);
       tools.push(ValidateMediaUpdateTool);
       tools.push(SortMediaTool);
+      // sort-children endpoints introduced in Umbraco 17.6; omit on older versions.
+      if (isUmbracoAtLeast(17, 6)) {
+        tools.push(SortMediaChildrenTool);
+        tools.push(SortMediaRootChildrenTool);
+      }
       tools.push(GetMediaByIdArrayTool);
       tools.push(MoveMediaTool);
       tools.push(GetMediaAuditLogTool);

--- a/src/umbraco-api/tools/media/put/sort-media-children.ts
+++ b/src/umbraco-api/tools/media/put/sort-media-children.ts
@@ -1,0 +1,33 @@
+import {
+  putMediaByIdSortChildrenParams,
+  putMediaByIdSortChildrenBody,
+} from "@/umbraco-api/umbracoManagementAPI.zod.js";
+import { z } from "zod";
+import {
+  type ToolDefinition,
+  CAPTURE_RAW_HTTP_RESPONSE,
+  executeVoidApiCall,
+  withStandardDecorators,
+} from "@umbraco-cms/mcp-server-sdk";
+
+const inputSchema = {
+  id: putMediaByIdSortChildrenParams.shape.id,
+  data: z.object(putMediaByIdSortChildrenBody.shape),
+};
+
+const SortMediaChildrenTool = {
+  name: "sort-media-children",
+  description: `Sorts the children of the media item identified by Id by a system field (Name, CreateDate or UpdateDate) in the given direction (Ascending or Descending).
+
+  This is DIFFERENT from sort-media: sort-media reorders children according to an explicit list of ids and sort orders you provide, whereas sort-media-children sorts every child of {id} automatically by the chosen field and direction - no explicit ordering is required.`,
+  inputSchema: inputSchema,
+  annotations: {},
+  slices: ['sort'],
+  handler: (async (model: { id: string; data: any }) => {
+    return executeVoidApiCall((client) =>
+      client.putMediaByIdSortChildren(model.id, model.data, CAPTURE_RAW_HTTP_RESPONSE)
+    );
+  }),
+} satisfies ToolDefinition<typeof inputSchema>;
+
+export default withStandardDecorators(SortMediaChildrenTool);

--- a/src/umbraco-api/tools/media/put/sort-media-root-children.ts
+++ b/src/umbraco-api/tools/media/put/sort-media-root-children.ts
@@ -1,0 +1,25 @@
+import { putMediaRootSortChildrenBody } from "@/umbraco-api/umbracoManagementAPI.zod.js";
+import { z } from "zod";
+import {
+  type ToolDefinition,
+  CAPTURE_RAW_HTTP_RESPONSE,
+  executeVoidApiCall,
+  withStandardDecorators,
+} from "@umbraco-cms/mcp-server-sdk";
+
+const SortMediaRootChildrenTool = {
+  name: "sort-media-root-children",
+  description: `Sorts the root-level media items by a system field (Name, CreateDate or UpdateDate) in the given direction (Ascending or Descending).
+
+  This is the root-level equivalent of sort-media-children: it sorts every media item at the root of the media library automatically by the chosen field and direction - no explicit ordering is required. This is DIFFERENT from sort-media, which reorders media items according to an explicit list of ids and sort orders you provide.`,
+  inputSchema: putMediaRootSortChildrenBody.shape,
+  annotations: {},
+  slices: ['sort'],
+  handler: (async (model: z.infer<typeof putMediaRootSortChildrenBody>) => {
+    return executeVoidApiCall((client) =>
+      client.putMediaRootSortChildren(model, CAPTURE_RAW_HTTP_RESPONSE)
+    );
+  }),
+} satisfies ToolDefinition<typeof putMediaRootSortChildrenBody.shape>;
+
+export default withStandardDecorators(SortMediaRootChildrenTool);

--- a/src/umbraco-api/tools/user/__tests__/__snapshots__/get-user-batch.test.ts.snap
+++ b/src/umbraco-api/tools/user/__tests__/__snapshots__/get-user-batch.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`get-user-batch should get multiple users in a single request 1`] = `
+{
+  "content": [],
+  "structuredContent": {
+    "items": [
+      {
+        "avatarUrls": [],
+        "createDate": "NORMALIZED_DATE",
+        "documentStartNodeIds": [],
+        "email": "test-user-batch-a-NORMALIZED@example.com",
+        "failedLoginAttempts": 0,
+        "hasDocumentRootAccess": false,
+        "hasMediaRootAccess": false,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "isAdmin": true,
+        "kind": "Default",
+        "languageIsoCode": "en-US",
+        "lastLockoutDate": null,
+        "lastLoginDate": null,
+        "lastPasswordChangeDate": "NORMALIZED_DATE",
+        "mediaStartNodeIds": [],
+        "name": "_Test User Batch A",
+        "state": "Inactive",
+        "updateDate": "NORMALIZED_DATE",
+        "userGroupIds": [
+          {
+            "id": "e5e7f6c8-7f9c-4b5b-8d5d-9e1e5a4f7e4d",
+          },
+        ],
+        "userName": "test-user-batch-a-NORMALIZED@example.com",
+      },
+      {
+        "avatarUrls": [],
+        "createDate": "NORMALIZED_DATE",
+        "documentStartNodeIds": [],
+        "email": "test-user-batch-b-NORMALIZED@example.com",
+        "failedLoginAttempts": 0,
+        "hasDocumentRootAccess": false,
+        "hasMediaRootAccess": false,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "isAdmin": true,
+        "kind": "Default",
+        "languageIsoCode": "en-US",
+        "lastLockoutDate": null,
+        "lastLoginDate": null,
+        "lastPasswordChangeDate": "NORMALIZED_DATE",
+        "mediaStartNodeIds": [],
+        "name": "_Test User Batch B",
+        "state": "Inactive",
+        "updateDate": "NORMALIZED_DATE",
+        "userGroupIds": [
+          {
+            "id": "e5e7f6c8-7f9c-4b5b-8d5d-9e1e5a4f7e4d",
+          },
+        ],
+        "userName": "test-user-batch-b-NORMALIZED@example.com",
+      },
+    ],
+    "total": 2,
+  },
+}
+`;

--- a/src/umbraco-api/tools/user/__tests__/get-user-batch.test.ts
+++ b/src/umbraco-api/tools/user/__tests__/get-user-batch.test.ts
@@ -1,0 +1,62 @@
+import GetUserBatchTool from "../get/get-user-batch.js";
+import { UserBuilder } from "./helpers/user-builder.js";
+import {
+  createMockRequestHandlerExtra,
+  createSnapshotResult,
+  setupTestEnvironment,
+  validateToolResponse,
+} from "@umbraco-cms/mcp-server-sdk/testing";
+
+const TEST_USER_NAME = "_Test User Batch A";
+const TEST_USER_EMAIL = `test-user-batch-a-${Math.floor(Math.random() * 10000)}@example.com`;
+const TEST_USER_NAME_2 = "_Test User Batch B";
+const TEST_USER_EMAIL_2 = `test-user-batch-b-${Math.floor(Math.random() * 10000)}@example.com`;
+
+describe("get-user-batch", () => {
+  setupTestEnvironment();
+
+  let userBuilder1: UserBuilder;
+  let userBuilder2: UserBuilder;
+
+  afterEach(async () => {
+    if (userBuilder1) {
+      await userBuilder1.cleanup();
+      userBuilder1 = undefined!;
+    }
+    if (userBuilder2) {
+      await userBuilder2.cleanup();
+      userBuilder2 = undefined!;
+    }
+  });
+
+  it("should get multiple users in a single request", async () => {
+    // Arrange
+    userBuilder1 = new UserBuilder()
+      .withName(TEST_USER_NAME)
+      .withUserName(TEST_USER_EMAIL)
+      .withEmail(TEST_USER_EMAIL);
+    await userBuilder1.create();
+
+    userBuilder2 = new UserBuilder()
+      .withName(TEST_USER_NAME_2)
+      .withUserName(TEST_USER_EMAIL_2)
+      .withEmail(TEST_USER_EMAIL_2);
+    await userBuilder2.create();
+
+    // Act
+    const result = await GetUserBatchTool.handler(
+      { id: [userBuilder1.getId(), userBuilder2.getId()] },
+      createMockRequestHandlerExtra()
+    );
+
+    // Assert
+    const data = validateToolResponse(GetUserBatchTool, result);
+    expect(data.total).toBe(2);
+    expect(data.items).toHaveLength(2);
+    const ids = data.items.map((i: any) => i.id).sort();
+    expect(ids).toEqual([userBuilder1.getId(), userBuilder2.getId()].sort());
+
+    const normalizedResult = createSnapshotResult(result);
+    expect(normalizedResult).toMatchSnapshot();
+  });
+});

--- a/src/umbraco-api/tools/user/get/get-user-batch.ts
+++ b/src/umbraco-api/tools/user/get/get-user-batch.ts
@@ -1,0 +1,24 @@
+import { GetUserBatchParams } from "@/umbraco-api/schemas/index.js";
+import { getUserBatchQueryParams, getUserBatchResponse } from "@/umbraco-api/umbracoManagementAPI.zod.js";
+import {
+  type ToolDefinition,
+  CAPTURE_RAW_HTTP_RESPONSE,
+  executeGetApiCall,
+  withStandardDecorators,
+} from "@umbraco-cms/mcp-server-sdk";
+
+const GetUserBatchTool = {
+  name: "get-user-batch",
+  description: "Gets multiple users identified by the provided Ids in one call.",
+  inputSchema: getUserBatchQueryParams.shape,
+  outputSchema: getUserBatchResponse.shape,
+  annotations: { readOnlyHint: true },
+  slices: ['read'],
+  handler: (async (params: GetUserBatchParams) => {
+    return executeGetApiCall((client) =>
+      client.getUserBatch(params, CAPTURE_RAW_HTTP_RESPONSE)
+    );
+  }),
+} satisfies ToolDefinition<typeof getUserBatchQueryParams.shape, typeof getUserBatchResponse.shape>;
+
+export default withStandardDecorators(GetUserBatchTool);

--- a/src/umbraco-api/tools/user/index.ts
+++ b/src/umbraco-api/tools/user/index.ts
@@ -10,6 +10,7 @@ import GetUserCurrentPermissionsTool from "./get/get-user-current-permissions.js
 import GetUserCurrentPermissionsDocumentTool from "./get/get-user-current-permissions-document.js";
 import GetUserCurrentPermissionsMediaTool from "./get/get-user-current-permissions-media.js";
 import GetUserByIdCalculateStartNodesTool from "./get/get-user-by-id-calculate-start-nodes.js";
+import GetUserBatchTool from "./get/get-user-batch.js";
 import UploadUserAvatarByIdTool from "./post/upload-user-avatar-by-id.js";
 import UploadUserCurrentAvatarTool from "./post/upload-user-current-avatar.js";
 import DeleteUserAvatarByIdTool from "./delete/delete-user-avatar-by-id.js";
@@ -17,6 +18,7 @@ import DeleteUserCurrentAvatarTool from "./delete/delete-user-current-avatar.js"
 import UpdateUserCurrentProfileTool from "./put/update-user-current-profile.js";
 import { AuthorizationPolicies } from "auth/umbraco-auth-policies.js";
 import { CurrentUserResponseModel } from "@/umbraco-api/schemas/index.js";
+import { isUmbracoAtLeast } from "../../runtime-context.js";
 import {
   type ToolCollectionExport,
   type ToolDefinition,
@@ -51,6 +53,10 @@ export const UserCollection: ToolCollectionExport = {
       tools.push(GetItemUserTool);
       tools.push(GetUserConfigurationTool);
       tools.push(GetUserByIdCalculateStartNodesTool);
+      // batch endpoint introduced in Umbraco 17.6; omit on older versions.
+      if (isUmbracoAtLeast(17, 6)) {
+        tools.push(GetUserBatchTool);
+      }
       tools.push(UploadUserAvatarByIdTool);
       tools.push(DeleteUserAvatarByIdTool);
     }


### PR DESCRIPTION
Release 17.6.3 — version bump across `package.json`, `package-lock.json`, `server.json`, `.claude-plugin/marketplace.json`.

Also adds `.github/workflows/release-tag.yml` for the v17 line (mirrors `main`'s, retargeted to `v17/main`) — this line had no automation to create the tag + GitHub Release on merge, unlike `main`.

Closes #415

🤖 Automated release via auto-release-loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_0122SZofKg3CKyL5Pn5BPNrb)_