### PR TITLE
chore: merge v17/main into v17/dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.6.2",
+    "version": "17.6.3",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.6.2",
+      "version": "17.6.3",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -40,4 +40,4 @@ jobs:
           esac
           git tag "$VERSION"
           git push origin "$VERSION"
-          gh release create "$VERSION" --title "$VERSION" --generate-notes $PRERELEASE_FLAG
+          gh release create "$VERSION" --title "$VERSION" --generate-notes --latest=false $PRERELEASE_FLAG

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,43 @@
+name: release-tag
+
+on:
+  push:
+    branches: [v17/main]
+
+permissions:
+  contents: write # push tags + create releases
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so we can see whether the tag already exists
+
+      - name: Read version
+        id: v
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether tag already exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.v.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag + GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ steps.v.outputs.version }}"
+          PRERELEASE_FLAG=""
+          case "$VERSION" in
+            *-alpha*|*-beta*|*-rc*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" --title "$VERSION" --generate-notes $PRERELEASE_FLAG

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -138,52 +138,6 @@ stages:
           displayName: Push to npm with dynamic tagging
           workingDirectory: $(Pipeline.Workspace)/npm-package
 
-- stage: Create_GitHub_Release
-  displayName: GitHub release
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/v17/main'))
-  dependsOn:
-    - Deploy_Npm
-  jobs:
-    - job: Release
-      displayName: Create GitHub Release
-      variables:
-        isStableRelease: $[ stageDependencies.Deploy_Npm.Publish.outputs['npmPublish.isStable'] ]
-      steps:
-        - checkout: self
-        - task: NodeTool@0
-          displayName: 'Use Node.js $(nodeVersion)'
-          inputs:
-            versionSpec: '$(nodeVersion)'
-        - script: |
-            VERSION=$(node -p "require('./package.json').version")
-            TAG="v${VERSION}"
-
-            # Determine if this is a prerelease
-            if [ "$(isStableRelease)" = "true" ]; then
-              PRERELEASE_FLAG=""
-            else
-              PRERELEASE_FLAG="--prerelease"
-            fi
-
-            # Generate release notes from commits since last tag
-            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-            if [ -n "$LAST_TAG" ]; then
-              NOTES=$(git log ${LAST_TAG}..HEAD --oneline --no-merges | sed 's/^/- /')
-            else
-              NOTES="Initial release"
-            fi
-
-            echo "Creating GitHub release ${TAG}"
-            gh release create "${TAG}" \
-              --target v17/main \
-              --title "${TAG}" \
-              --notes "${NOTES}" \
-              --latest=false \
-              ${PRERELEASE_FLAG}
-          displayName: 'Create GitHub Release'
-          env:
-            GH_TOKEN: $(MCP_REGISTRY_GITHUB_TOKEN)
-
 # MCP Registry publishing is temporarily disabled — the registry auth token has
 # expired/is invalid, and publish steps were failing. Re-enable once a valid
 # MCP_REGISTRY_GITHUB_TOKEN is in place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.2",
+  "version": "17.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.6.2",
+      "version": "17.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.2",
+  "version": "17.6.3",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.6.2",
+  "version": "17.6.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.6.2",
+      "version": "17.6.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Sync of release commits from `v17/main` back into `v17/dev` after publishing v17.6.3 (#415, #416).

`v17/main` has no `sync-main-to-dev.yml` automation (unlike `main`), so this is done by hand — same convention as the prior sync PR #411.

Carries: the 17.6.3 version bump, and the `release-tag.yml`/`azure-pipelines.yml` fix from PR #416 (removed the duplicate Azure release stage, restored `--latest=false` on the GitHub Actions side).

---
_Generated by [Claude Code](https://claude.ai/code/session_0122SZofKg3CKyL5Pn5BPNrb)_