### PR TITLE
Fix: --call no longer races into MCP server mode on piped/open stdin

### DIFF
--- a/src/__tests__/cli-await-ordering.test.ts
+++ b/src/__tests__/cli-await-ordering.test.ts
@@ -1,0 +1,107 @@
+import { jest } from "@jest/globals";
+
+// Regression test for #424: `handleCliCommands(...)` in src/index.ts must be
+// awaited. `handleCliCommands` exits the process itself once a CLI flag
+// (--list-tools, --call, ...) is handled, but for `--call` that happens only
+// after an internal `await` (the tool's own async handler). If the call site
+// doesn't await it, main() races ahead into `new McpServer()` /
+// `StdioServerTransport` / `server.connect()` — attaching a stdin listener —
+// while the `--call` tool handler is still running. A caller that leaves
+// stdin open/piped (the exact repro in #424) then hits a live MCP stdio
+// server it never asked for, instead of getting its `--call` result.
+//
+// This test doesn't depend on real network/tool timing (which is fast and
+// hides the race on localhost — see PR discussion): it fully mocks the SDK
+// boundary and gives the CLI-commands path an artificial delay, so the test
+// deterministically fails if the `await` is ever dropped again, regardless
+// of machine speed.
+describe("CLI bootstrap ordering (regression for #424)", () => {
+  const realExit = process.exit;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.exit = realExit;
+  });
+
+  it("never connects the stdio transport before the CLI command handling settles", async () => {
+    const events: string[] = [];
+
+    const handleCliCommands = jest.fn(async () => {
+      // Mirrors the real `--call` branch: it resolves via an internal
+      // `await` (the tool's own async handler) before the function would
+      // go on to call `process.exit()`.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      events.push("cli-commands-settled");
+    });
+
+    class FakeTransport {}
+    class FakeServer {
+      constructor(..._args: unknown[]) {}
+      async connect(..._args: unknown[]) {
+        events.push("server-connect");
+      }
+    }
+
+    jest.unstable_mockModule("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+      McpServer: FakeServer,
+    }));
+    jest.unstable_mockModule("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+      StdioServerTransport: FakeTransport,
+    }));
+    jest.unstable_mockModule("@umbraco-cms/mcp-server-sdk", () => ({
+      checkUmbracoVersion: jest.fn(async () => undefined),
+      configureVersionCheckHook: jest.fn(),
+      getVersionCheckMessage: jest.fn(() => undefined),
+      configureApiClient: jest.fn(),
+      initializeUmbracoFetch: jest.fn(),
+      getServerConfig: jest.fn(async () => ({
+        cliFlags: { callTool: "get-server-information" },
+      })),
+      handleCliCommands,
+      createCollectionConfigLoader: jest.fn(() => ({
+        loadFromConfig: () => ({}),
+      })),
+    }));
+    jest.unstable_mockModule("@umb-management-client", () => ({
+      UmbracoManagementClient: {
+        getClient: () => ({
+          getUserCurrent: async () => ({}),
+          getServerInformation: async () => ({ version: "18.0.0" }),
+        }),
+      },
+    }));
+    jest.unstable_mockModule("../config/index.js", () => ({
+      loadServerConfig: jest.fn(async () => ({ umbraco: { auth: {} } })),
+      clearConfigCache: jest.fn(),
+      allModes: {},
+      allModeNames: [],
+      allSliceNames: [],
+    }));
+    jest.unstable_mockModule("../umbraco-api/tools/collection-registry.js", () => ({
+      availableCollections: [],
+    }));
+    jest.unstable_mockModule("../umbraco-api/tools/tool-factory.js", () => ({
+      UmbracoToolFactory: jest.fn(),
+    }));
+
+    // Safety net: if any mock above is incomplete, main()'s catch handler
+    // calls the real process.exit(1), which would kill the Jest worker.
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit(${code}) called during test`);
+    }) as never;
+
+    // Importing src/index.ts triggers `main().catch(...)` as a module
+    // side-effect — exactly like running the CLI.
+    await import("../index.js");
+
+    // Let both the delayed CLI-command handling and any (buggy) unawaited
+    // continuation of main() run to completion.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(events).toContain("cli-commands-settled");
+    expect(events).toContain("server-connect");
+    expect(events.indexOf("cli-commands-settled")).toBeLessThan(
+      events.indexOf("server-connect"),
+    );
+  });
+});

--- a/src/__tests__/cli-call-stdin.test.ts
+++ b/src/__tests__/cli-call-stdin.test.ts
@@ -1,0 +1,54 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+// Regression test for #424: invoking the CLI with `--call` while stdin is
+// left open/piped (e.g. `execFileSync(node, [cliPath, '--call', tool, ...])`
+// without `stdio: ['ignore', ...]`) used to race the one-shot `--call`
+// handler against the normal server bootstrap. `handleCliCommands` was
+// called without an `await` in src/index.ts, so `main()` could reach
+// `StdioServerTransport`/`server.connect()` — attaching a stdin listener —
+// before the (async) tool call had a chance to run `process.exit()`. A
+// caller that never writes to or closes stdin then hangs forever waiting
+// for MCP protocol input instead of getting its `--call` result.
+describe("CLI --call with piped/open stdin", () => {
+  const CLI_PATH = path.resolve(process.cwd(), "dist/index.js");
+
+  it("executes the tool call and exits promptly without waiting on stdin", async () => {
+    const child = spawn(process.execPath, [CLI_PATH, "--call", "get-server-information"], {
+      // Deliberately mirror the reported repro: stdin is a pipe that is
+      // never written to and never closed by us. If the CLI ever attaches
+      // a stdio MCP transport, the process will hang until this test's
+      // timeout kills it.
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+    child.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(
+          new Error(
+            `CLI did not exit within the timeout (likely hung waiting on stdin). stdout=${stdout} stderr=${stderr}`,
+          ),
+        );
+      }, 20000);
+
+      child.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("version");
+  }, 25000);
+});

--- a/src/__tests__/cli-call-stdin.test.ts
+++ b/src/__tests__/cli-call-stdin.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 // Regression test for #424: invoking the CLI with `--call` while stdin is
@@ -12,6 +13,23 @@ import path from "node:path";
 // for MCP protocol input instead of getting its `--call` result.
 describe("CLI --call with piped/open stdin", () => {
   const CLI_PATH = path.resolve(process.cwd(), "dist/index.js");
+  const SRC_PATH = path.resolve(process.cwd(), "src/index.ts");
+
+  beforeAll(() => {
+    // This test spawns the built bundle, not source-through-ts-jest like the
+    // rest of the suite. `npm test` alone doesn't build (only `npm run
+    // test:all` does), so a stale or missing dist/index.js would otherwise
+    // let this test silently pass against old behaviour or fail with a
+    // confusing ENOENT/non-zero-exit unrelated to the current source.
+    if (!fs.existsSync(CLI_PATH)) {
+      throw new Error(`${CLI_PATH} is missing — run \`npm run build\` before this test.`);
+    }
+    if (fs.statSync(CLI_PATH).mtimeMs < fs.statSync(SRC_PATH).mtimeMs) {
+      throw new Error(
+        `${CLI_PATH} is older than ${SRC_PATH} — run \`npm run build\` before this test.`,
+      );
+    }
+  });
 
   it("executes the tool call and exits promptly without waiting on stdin", async () => {
     const child = spawn(process.execPath, [CLI_PATH, "--call", "get-server-information"], {
@@ -48,7 +66,9 @@ describe("CLI --call with piped/open stdin", () => {
       });
     });
 
-    expect(exitCode).toBe(0);
+    if (exitCode !== 0) {
+      throw new Error(`CLI exited with code ${exitCode} (expected 0). stdout=${stdout} stderr=${stderr}`);
+    }
     expect(stdout).toContain("version");
   }, 25000);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const main = async () => {
 
   const user = await client.getUserCurrent();
 
-  // Handle CLI introspection flags (--list-tools, --describe-tool, --generate-context)
+  // Handle CLI introspection flags (--list-tools, --describe-tool, --generate-context, --call)
   // This runs after auth so we have the real user for tool filtering
   const rawConfig = await getServerConfig(true);
   const configLoader = createCollectionConfigLoader({
@@ -43,7 +43,13 @@ const main = async () => {
     allSliceNames,
   });
   const filterConfig = configLoader.loadFromConfig(config);
-  handleCliCommands(availableCollections, {
+  // Must be awaited: handleCliCommands exits the process itself for every
+  // recognized flag, but --call resolves via an async tool handler before it
+  // gets there. Without awaiting, main() races ahead into MCP server startup
+  // (StdioServerTransport attaches to stdin) while the tool call is still in
+  // flight — a programmatic caller with piped/open stdin then hangs waiting
+  // on MCP protocol input instead of getting the --call result. See #424.
+  await handleCliCommands(availableCollections, {
     cliFlags: rawConfig.cliFlags,
     serverName: "Umbraco CMS Developer MCP Server",
     serverVersion: packageJson.version,


### PR DESCRIPTION
## What changed

`src/index.ts` called `handleCliCommands(...)` (from `@umbraco-cms/mcp-server-sdk`) without `await`ing it.

`handleCliCommands` exits the process itself once it recognizes a CLI flag (`--list-tools`, `--describe-tool`, `--generate-context`, `--debug-config`, `--call`). For most of those flags it does so synchronously (no `await` before `process.exit()`), so the missing `await` at the call site was harmless. But the `--call` branch resolves via an internal `await` — the tool's own async handler runs first — before it can call `process.exit()`.

Because the call site didn't await it, `main()` could race ahead: it kept running the normal server-bootstrap sequence (`client.getServerInformation()` → `new McpServer()` → `new StdioServerTransport()` → `server.connect()`, which attaches a stdin listener) *while* the `--call` tool handler was still in flight. A programmatic caller that leaves stdin open/piped (e.g. `execFileSync(node, [cliPath, '--call', tool, ...])` without `stdio: ['ignore', ...]`) can end up with a live MCP stdio listener it never asked for, instead of its `--call` result — matching the hang described in #424.

The fix is a single `await`:

```diff
- handleCliCommands(availableCollections, {
+ await handleCliCommands(availableCollections, {
```

This makes the sequencing structural rather than a timing-dependent race: once any recognized one-shot/introspection flag is present, `handleCliCommands` fully settles (and the process exits) before `main()` can ever reach server bootstrap.

## Tests

- **`src/__tests__/cli-await-ordering.test.ts`** (new, deterministic, no live Umbraco needed): mocks the SDK boundary (`handleCliCommands`, `McpServer`, `StdioServerTransport`, etc.) and gives the CLI-command handling an artificial async delay, then asserts `server.connect()` is never called before `handleCliCommands` settles. Verified this **fails** against the pre-fix code (`server-connect` fires before `cli-commands-settled`) and **passes** against the fix. This is the real regression guard — the actual race is timing-dependent and did *not* reproduce reliably against a fast localhost Umbraco (15/15 runs succeeded even on the buggy code), so a purely timing-based test wouldn't have caught a future regression.
- **`src/__tests__/cli-call-stdin.test.ts`** (new, live end-to-end): spawns the built CLI (`dist/index.js`) with `--call get-server-information` and stdin left open/piped (`stdio: ['pipe','pipe','pipe']`, never written to or closed) against a real local Umbraco instance, and asserts it exits with code 0 within a bounded timeout — the literal repro scenario from the issue.

Both ran green locally against a real Umbraco instance (SQL Server provider, CI-parity):
```
PASS src/__tests__/cli-call-stdin.test.ts
PASS src/__tests__/cli-await-ordering.test.ts
```

Also ran clean:
- `npm run compile`
- `npm run test:changed` (picks up and runs both new test files)

Not run: full `npm test` suite / CI (will be watched after this PR opens).

## Note (not fixed here, out of scope)

While investigating, noticed `scripts/test-changed.mjs`'s pathspec `"src/**/*.ts"` doesn't match top-level files directly under `src/` (e.g. `src/index.ts` itself) when computing the changed-files diff — only files at least one directory deep. Didn't touch it since it's unrelated to this issue and `--findRelatedTests` still finds the right tests once given the correct path directly. Flagging in case it's worth a follow-up issue.

Closes #424


---
_Generated by [Claude Code](https://claude.ai/code/session_01PsU8VsfHkd6u7CFQmw6x6p)_