### PR TITLE
docs: document the 17.x LTS line, per-line release flow, and issue lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,70 @@ node scripts/create-api-user.mjs
 
 The script is idempotent (it checks for the user first and exits if already present).
 
+## Branching & releases
+
+This repo maintains **two live majors in parallel**, each with its own gitflow pair. The
+generic `release-and-branching` skill assumes a single `dev`/`main` pair — that is only true
+of the 18 line here, so the table below wins over the skill.
+
+| Line | Status | Work branches off | Release PR into | Latest tag |
+|---|---|---|---|---|
+| **18.x** | current | `dev` | `main` | `v18.1.2` |
+| **17.x** | **maintained (LTS)** | `v17/dev` | `v17/main` | `v17.6.3` |
+| **16.x** | archived — no `v16/dev`, don't target it | — | — | `v16.0.1` |
+
+`main` is and stays the repo's **default branch**. Don't retarget PRs at `main` or move the
+default branch to make GitHub's closing keywords fire (see *Issue lifecycle* below) — that
+would break the release flow.
+
+### Picking a line
+
+Work goes on the **18 line by default**: branch off `dev`, PR into `dev`, squash-merge.
+Only branch off `v17/dev` when the issue is explicitly a 17.x fix.
+
+**Do not create back-ports to the 17 line.** A fix landing on `dev` is 18-only unless a
+maintainer explicitly asks for a 17 back-port — don't open back-port PRs or issues off your
+own judgement, and don't treat "17 is still supported" as a standing instruction to port.
+
+### Cutting a release
+
+Same shape on both lines, one level over:
+
+1. Branch `release/<version>` off the line's dev branch (`dev`, or `v17/dev`).
+2. Bump the version and verify no stale version strings remain.
+3. PR into the line's main branch (`main`, or `v17/main`).
+4. Merge with a **merge commit, never a squash** — `release-tag.yml` keys off the real
+   version-bump commit.
+
+`release-tag.yml` then tags `v<version>` and creates the GitHub Release. It exists on both
+lines, each triggering on its own branch (`main` on the 18 line, `v17/main` on the 17 line).
+
+**Merge-back differs between the lines:** the 18 line has `sync-main-to-dev.yml`, which
+merges `main` back into `dev` automatically. The 17 line has **no such workflow** — after a
+17.x release, merge `v17/main` back into `v17/dev` by hand via a
+`chore/merge-v17-main-to-v17-dev` branch (as in #418, #411).
+
+### Issue lifecycle & labels
+
+Issues move through one stage label at a time:
+
+| Label | Meaning |
+|---|---|
+| `ready-for-ai` | queued for the issue loop to build. Adding it triggers a build. |
+| `generated-by-ai` | built — a PR is open. |
+| `ready-for-release` | the PR is **merged**, but the fix hasn't shipped in a tag yet. |
+
+**Close issues at release, not at merge.** An issue stays open with `ready-for-release` from
+the moment its PR merges until the version containing it is tagged — that's what makes
+"finished but not released" visible on the board. Filter `label:ready-for-release` to see
+exactly what a pending release will close.
+
+This is manual by necessity: `main` is the default branch, and GitHub only fires a PR's
+`Closes #N` keyword on a merge into the **default** branch. Merges into `dev`, `v17/dev` or
+`v17/main` never auto-close their linked issue, so nothing closes at merge time and nothing
+closes at release time either — closing out `ready-for-release` issues is a step in cutting
+a release.
+
 ## PR / CI workflow
 
 Whenever you create a new PR or push updates to an existing PR, do NOT consider the task done at push time. Watch the CI checks and fix any failures automatically:


### PR DESCRIPTION
## Why

`CLAUDE.md` had no branching or release section, so the generic `release-and-branching` skill applied by default — and that skill states the branches "are always `dev` and `main`". That's true of the 18 line only. The 17 line is still maintained as an LTS on `v17/dev` → `v17/main`, so an agent (or a person) following the skill alone would branch off `dev` and fix the wrong line.

It also writes down the issue-lifecycle convention we settled on, including why closing has to be manual.

## What changed

One new `## Branching & releases` section in `CLAUDE.md`. No code, no behaviour change.

- **The three lines** — 18.x current (`dev` → `main`, `v18.1.2`), 17.x maintained LTS (`v17/dev` → `v17/main`, `v17.6.3`), 16.x archived (no `v16/dev`, `v16.0.1`). `main` stays the default branch.
- **Back-port policy** — fixes landing on `dev` are 18-only. Back-ports to the 17 line are **not** created off our own judgement; a maintainer has to ask.
- **Per-line release steps** — `release/<version>` off the line's dev branch, PR into the line's main branch, merge commit never squash. `release-tag.yml` exists on both lines with its own trigger branch (`main` / `v17/main`).
- **The merge-back asymmetry** — the 18 line has `sync-main-to-dev.yml`; the 17 line has no equivalent, so `v17/main` → `v17/dev` is a manual `chore/merge-v17-main-to-v17-dev` branch (as in #418, #411).
- **Label pipeline** — `ready-for-ai` → `generated-by-ai` → `ready-for-release`, and close at release rather than at merge, so "finished but not released" stays visible. `label:ready-for-release` lists what a pending release will close.
- **Why closing is manual** — GitHub only fires a PR's `Closes #N` keyword on a merge into the **default** branch. Merges into `dev`, `v17/dev` or `v17/main` never auto-close, so nothing closes at merge and nothing closes at release either.

## Notes for the reviewer

- **Base branch.** Opened against `main` to match "keep the base as main". If that meant only "leave the default branch alone" and this should follow normal gitflow, retargeting to `dev` is a one-click change — `main` is an ancestor of `dev`, so it merges cleanly either way.
- The companion change to the shared `release-and-branching` skill (teaching `gitflow.md` about a parallel maintenance line) belongs in the ops repo and is **not** in this PR — this session can't reach that repo.
- `ready-for-release` has been created and applied to #425, #424 and #420. It was auto-created by the API, so it's still default grey with no description.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCg3cE8L4PHuYhCiwQVhha)_