### PR TITLE
chore: merge main into dev (release 18.1.3 sync-back)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.2",
+  "version": "18.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "18.1.2",
+      "version": "18.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.2",
+  "version": "18.1.3",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "18.1.2",
+  "version": "18.1.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "18.1.2",
+      "version": "18.1.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Automated sync of release 18.1.3 commits from `main` back into `dev` (fast-forward, version-bump only).

Supersedes #446: that PR was opened by `sync-main-to-dev.yml` using the workflow's own `GITHUB_TOKEN`, which GitHub does not allow to trigger other `pull_request`-triggered workflows — so its required "Test Suite" check could never run, permanently blocking the merge. This PR carries the identical diff, pushed under a real identity so CI runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvcrLMepE57dev2esY5q6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvcrLMepE57dev2esY5q6z)_