### PR TITLE
chore: merge main into dev (release 18.1.4 sync-back)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.3",
+  "version": "18.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "18.1.3",
+      "version": "18.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "18.1.3",
+  "version": "18.1.4",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "18.1.3",
+  "version": "18.1.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "18.1.3",
+      "version": "18.1.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Automated sync of release 18.1.4 commits from `main` back into `dev` (fast-forward, version-bump + beta.39 SDK upgrade only).

Supersedes #459: that PR was opened by `sync-main-to-dev.yml` using the workflow's own `GITHUB_TOKEN`, which GitHub does not allow to trigger other `pull_request`-triggered workflows — so its required "Test Suite" check could never run, permanently blocking the merge (same issue previously fixed for the 18.1.3 sync via #451). This PR carries the identical diff, pushed under a real identity so CI runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StTv5raceQGJmHwwWPGcAc

---
_Generated by [Claude Code](https://claude.ai/code/session_01StTv5raceQGJmHwwWPGcAc)_