### PR TITLE
fix: correct developer MCP's OAuth client id (umbraco-cms-dev-mcp-hosted -> umbraco-cms-developer-mcp-hosted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For complete installation instructions, configuration options, tool listings, an
 The Cloudflare Worker entry point (`src/worker.ts`) supports two deployment modes, selected at request time by the `@umbraco-cms/mcp-hosted` library:
 
 - **Single-tenant** (default) — the worker authenticates against the `UMBRACO_BASE_URL` configured in `wrangler.toml`. This is the existing behavior and requires no extra configuration.
-- **Multi-tenant Umbraco Cloud** — set `UMBRACO_CLOUD_ROUTING_ENABLED = "true"` under `[vars]` in `wrangler.toml`. Requests to `/at/{alias}/...` resolve the upstream Umbraco Cloud project for `{alias}` and issue access tokens scoped to that resource per the MCP resource-indicator spec. Each Umbraco Cloud project served by the worker must register an OpenIddict client with id `umbraco-cms-dev-mcp-hosted`.
+- **Multi-tenant Umbraco Cloud** — set `UMBRACO_CLOUD_ROUTING_ENABLED = "true"` under `[vars]` in `wrangler.toml`. Requests to `/at/{alias}/...` resolve the upstream Umbraco Cloud project for `{alias}` and issue access tokens scoped to that resource per the MCP resource-indicator spec. Each Umbraco Cloud project served by the worker must register an OpenIddict client with id `umbraco-cms-developer-mcp-hosted`.
 
 `siteRouting` is wired unconditionally; the per-request toggle is the env var.
 

--- a/demo-site-template/McpOAuthComposer.cs
+++ b/demo-site-template/McpOAuthComposer.cs
@@ -32,7 +32,7 @@ public class RegisterMcpClientHandler
         UmbracoApplicationStartingNotification notification,
         CancellationToken cancellationToken)
     {
-        const string clientId = "umbraco-cms-dev-mcp-hosted";
+        const string clientId = "umbraco-cms-developer-mcp-hosted";
 
         var existing = await _applicationManager.FindByClientIdAsync(clientId, cancellationToken);
         if (existing is not null)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,7 +53,7 @@ const options: HostedMcpServerOptions = {
   enableConsentToolSelection: true,
   authOptions: { showReauthButton: true },
   clientFactory: () => UmbracoManagementClient.getClient(),
-  siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-dev-mcp-hosted" }),
+  siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-developer-mcp-hosted" }),
   telemetry: { tracing },
 };
 

--- a/tests/cms-hosted-e2e/helpers/worker-setup.ts
+++ b/tests/cms-hosted-e2e/helpers/worker-setup.ts
@@ -13,7 +13,7 @@ let workerUrl: string | undefined;
 const BASE_VARS = {
   UMBRACO_BASE_URL: "https://localhost:44391",
   UMBRACO_SERVER_URL: "http://localhost:56472",
-  UMBRACO_OAUTH_CLIENT_ID: "umbraco-cms-dev-mcp-hosted",
+  UMBRACO_OAUTH_CLIENT_ID: "umbraco-cms-developer-mcp-hosted",
   COOKIE_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   ENABLE_INFO_ENDPOINT: "true",
   NODE_TLS_REJECT_UNAUTHORIZED: "0",


### PR DESCRIPTION
## Summary

- `src/worker.ts` requests OAuth client_id `umbraco-cms-dev-mcp-hosted` — but `"dev"` isn't a real dimension anywhere else in the hosted MCP setup. The naming convention (confirmed against `umbraco-cloud-hosted-mcp`'s terraform catalog) is `{product}.{mcp-type}.{major}[.{env}]`, and `mcp-type` is always `editor` or `developer` — never `dev`. The `.dev.` label in hostnames (`cms.developer.17.dev.mcp.umbraco.ai`) is the deploy **environment**, a completely separate dimension.
- `Umbraco.Mcp.Cloud.HostedAuth` (the C# package customers install to wire up OAuth) registers clients by that exact convention: `umbraco-{product}-{variant}-mcp-hosted`. It always registers `umbraco-cms-developer-mcp-hosted` — an application this worker never actually asked for.
- Result: every developer MCP connection attempt fails OpenIddict authorization with `ID2052` — "the specified 'client_id' is invalid" — while CMS editor (whose id, `umbraco-cms-editor-mcp-hosted`, already followed the convention) connects fine on the same Umbraco instance. Confirmed against a customer report matching this exact symptom.

## Fix

Corrects the three places that had drifted to the wrong id:
- `src/worker.ts` — the actual OAuth client_id the deployed worker requests.
- `README.md` — docs describing the required OpenIddict client registration.
- `tests/cms-hosted-e2e/helpers/worker-setup.ts` — E2E test config, for consistency.

No change needed in `Umbraco.Mcp.Cloud.HostedAuth` — it already registers the correct id by default; this worker just needs to ask for it.

## Rollout note

This id is baked into the compiled Worker bundle (not an env var — see `umbraco-cloud-hosted-mcp/terraform/mcps.auto.tfvars`'s own comment: "OAuth client id is baked into the MCP's src/worker.ts; not an env var"), so **the deployed Cloudflare Worker needs a fresh `wrangler deploy` after this merges** for the fix to take effect — merging alone won't fix live connections.

## Test plan

- [x] `npm install && npm run compile` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)