### PR TITLE
fix: correct developer MCP's OAuth client id (v17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For complete installation instructions, configuration options, tool listings, an
 The Cloudflare Worker entry point (`src/worker.ts`) supports two deployment modes, selected at request time by the `@umbraco-cms/mcp-hosted` library:
 
 - **Single-tenant** (default) — the worker authenticates against the `UMBRACO_BASE_URL` configured in `wrangler.toml`. This is the existing behavior and requires no extra configuration.
-- **Multi-tenant Umbraco Cloud** — set `UMBRACO_CLOUD_ROUTING_ENABLED = "true"` under `[vars]` in `wrangler.toml`. Requests to `/at/{alias}/...` resolve the upstream Umbraco Cloud project for `{alias}` and issue access tokens scoped to that resource per the MCP resource-indicator spec. Each Umbraco Cloud project served by the worker must register an OpenIddict client with id `umbraco-cms-dev-mcp-hosted`.
+- **Multi-tenant Umbraco Cloud** — set `UMBRACO_CLOUD_ROUTING_ENABLED = "true"` under `[vars]` in `wrangler.toml`. Requests to `/at/{alias}/...` resolve the upstream Umbraco Cloud project for `{alias}` and issue access tokens scoped to that resource per the MCP resource-indicator spec. Each Umbraco Cloud project served by the worker must register an OpenIddict client with id `umbraco-cms-developer-mcp-hosted`.
 
 `siteRouting` is wired unconditionally; the per-request toggle is the env var.
 

--- a/demo-site-template/McpOAuthComposer.cs
+++ b/demo-site-template/McpOAuthComposer.cs
@@ -32,7 +32,7 @@ public class RegisterMcpClientHandler
         UmbracoApplicationStartingNotification notification,
         CancellationToken cancellationToken)
     {
-        const string clientId = "umbraco-cms-dev-mcp-hosted";
+        const string clientId = "umbraco-cms-developer-mcp-hosted";
 
         var existing = await _applicationManager.FindByClientIdAsync(clientId, cancellationToken);
         if (existing is not null)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,7 +53,7 @@ const options: HostedMcpServerOptions = {
   enableConsentToolSelection: true,
   authOptions: { showReauthButton: true },
   clientFactory: () => UmbracoManagementClient.getClient(),
-  siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-dev-mcp-hosted" }),
+  siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-developer-mcp-hosted" }),
   telemetry: { tracing },
 };
 

--- a/tests/cms-hosted-e2e/helpers/worker-setup.ts
+++ b/tests/cms-hosted-e2e/helpers/worker-setup.ts
@@ -13,7 +13,7 @@ let workerUrl: string | undefined;
 const BASE_VARS = {
   UMBRACO_BASE_URL: "https://localhost:44391",
   UMBRACO_SERVER_URL: "http://localhost:56472",
-  UMBRACO_OAUTH_CLIENT_ID: "umbraco-cms-dev-mcp-hosted",
+  UMBRACO_OAUTH_CLIENT_ID: "umbraco-cms-developer-mcp-hosted",
   COOKIE_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   ENABLE_INFO_ENDPOINT: "true",
   NODE_TLS_REJECT_UNAUTHORIZED: "0",


### PR DESCRIPTION
Same fix as #463 on \`dev\` — see that PR for the full writeup and the rollout note (Worker needs a fresh deploy after merge for the fix to take effect).

## Test plan

- [x] \`npm install && npm run compile\` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)