### PR TITLE
release: 17.6.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.6.5",
+    "version": "17.6.6",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.6.5",
+      "version": "17.6.6",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For complete installation instructions, configuration options, tool listings, an
 The Cloudflare Worker entry point (`src/worker.ts`) supports two deployment modes, selected at request time by the `@umbraco-cms/mcp-hosted` library:
 
 - **Single-tenant** (default) — the worker authenticates against the `UMBRACO_BASE_URL` configured in `wrangler.toml`. This is the existing behavior and requires no extra configuration.
-- **Multi-tenant Umbraco Cloud** — set `UMBRACO_CLOUD_ROUTING_ENABLED = "true"` under `[vars]` in `wrangler.toml`. Requests to `/at/{alias}/...` resolve the upstream Umbraco Cloud project for `{alias}` and issue access tokens scoped to that resource per the MCP resource-indicator spec. Each Umbraco Cloud project served by the worker must register an OpenIddict client with id `umbraco-cms-dev-mcp-hosted`.
+- **Multi-tenant Umbraco Cloud** — set `UMBRACO_CLOUD_ROUTING_ENABLED = "true"` under `[vars]` in `wrangler.toml`. Requests to `/at/{alias}/...` resolve the upstream Umbraco Cloud project for `{alias}` and issue access tokens scoped to that resource per the MCP resource-indicator spec. Each Umbraco Cloud project served by the worker must register an OpenIddict client with id `umbraco-cms-developer-mcp-hosted`.
 
 `siteRouting` is wired unconditionally; the per-request toggle is the env var.
 

--- a/demo-site-template/McpOAuthComposer.cs
+++ b/demo-site-template/McpOAuthComposer.cs
@@ -32,7 +32,7 @@ public class RegisterMcpClientHandler
         UmbracoApplicationStartingNotification notification,
         CancellationToken cancellationToken)
     {
-        const string clientId = "umbraco-cms-dev-mcp-hosted";
+        const string clientId = "umbraco-cms-developer-mcp-hosted";
 
         var existing = await _applicationManager.FindByClientIdAsync(clientId, cancellationToken);
         if (existing is not null)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.5",
+  "version": "17.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.6.5",
+      "version": "17.6.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.5",
+  "version": "17.6.6",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.6.5",
+  "version": "17.6.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.6.5",
+      "version": "17.6.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,7 +53,7 @@ const options: HostedMcpServerOptions = {
   enableConsentToolSelection: true,
   authOptions: { showReauthButton: true },
   clientFactory: () => UmbracoManagementClient.getClient(),
-  siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-dev-mcp-hosted" }),
+  siteRouting: umbracoCloudSiteRouting({ oauthClientId: "umbraco-cms-developer-mcp-hosted" }),
   telemetry: { tracing },
 };
 

--- a/tests/cms-hosted-e2e/helpers/worker-setup.ts
+++ b/tests/cms-hosted-e2e/helpers/worker-setup.ts
@@ -13,7 +13,7 @@ let workerUrl: string | undefined;
 const BASE_VARS = {
   UMBRACO_BASE_URL: "https://localhost:44391",
   UMBRACO_SERVER_URL: "http://localhost:56472",
-  UMBRACO_OAUTH_CLIENT_ID: "umbraco-cms-dev-mcp-hosted",
+  UMBRACO_OAUTH_CLIENT_ID: "umbraco-cms-developer-mcp-hosted",
   COOKIE_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   ENABLE_INFO_ENDPOINT: "true",
   NODE_TLS_REJECT_UNAUTHORIZED: "0",


### PR DESCRIPTION
Release 17.6.6 — version bump across `package.json`, `package-lock.json`, `server.json`, `.claude-plugin/marketplace.json` (v17 maintenance line).

Closes #466

🤖 Automated release via auto-release-loop.

https://claude.ai/code/session_01HBx9opPjh729UXs9oaqBpT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBx9opPjh729UXs9oaqBpT)_