### PR TITLE
chore: merge v17/main into v17/dev (17.6.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for Umbraco CMS MCP Server - CLI operation, tool filtering, and runtime configuration",
-    "version": "17.6.5",
+    "version": "17.6.6",
     "homepage": "https://github.com/umbraco/Umbraco-MCP-CMS"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umb-cms-mcp",
       "source": "./plugins-server",
       "description": "Skills for CLI operation of Umbraco MCP servers - CLI setup, tool filtering, introspection, and runtime modes",
-      "version": "17.6.5",
+      "version": "17.6.6",
       "category": "operations",
       "author": {
         "name": "Phil W",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.5",
+  "version": "17.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-cms/mcp-dev",
-      "version": "17.6.5",
+      "version": "17.6.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-cms/mcp-dev",
-  "version": "17.6.5",
+  "version": "17.6.6",
   "type": "module",
   "description": "A model context protocol (MCP) server for Umbraco CMS",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/umbraco/Umbraco-CMS-MCP-Dev",
     "source": "github"
   },
-  "version": "17.6.5",
+  "version": "17.6.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@umbraco-cms/mcp-dev",
-      "version": "17.6.5",
+      "version": "17.6.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Syncs the 17.6.6 release (version bump) from `v17/main` back into `v17/dev`.

🤖 Automated via auto-release-loop.

https://claude.ai/code/session_01HBx9opPjh729UXs9oaqBpT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBx9opPjh729UXs9oaqBpT)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBx9opPjh729UXs9oaqBpT)_